### PR TITLE
Base Monitoring of Directories to track File Changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,24 @@
 version: 2.1
 
 orbs:
-  rebar3: tsloughter/rebar3@0.5.1
+  rebar3: tsloughter/rebar3@0.5.4
+
+jobs:
+  proper:
+    executor: rebar3/erlang
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project/
+      - run:
+          command: |
+              rebar3 proper --regressions
+              rebar3 proper -c
+      # for cover
+      - persist_to_workspace:
+          root: ~/project/
+          paths:
+            - _build/test/
 
 workflows:
   version: 2.1
@@ -20,6 +37,11 @@ workflows:
       - rebar3/ct:
           requires:
               - rebar3/compile
+      - proper:
+          requires:
+              - rebar3/compile
+              - rebar3/ct # to make cover work, can't be concurrent
       - rebar3/cover:
           requires:
               - rebar3/ct
+              - proper

--- a/apps/revault/src/revault.app.src
+++ b/apps/revault/src/revault.app.src
@@ -5,7 +5,8 @@
   {mod, {revault_app, []}},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    gproc
    ]},
   {env,[]},
   {modules, []},

--- a/apps/revault/src/revault_dirmon_event.erl
+++ b/apps/revault/src/revault_dirmon_event.erl
@@ -1,0 +1,66 @@
+-module(revault_dirmon_event).
+-export([start_link/2, force_scan/2, stop/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-record(state, {name :: term(),
+                directory :: file:filename(),
+                poll_delay :: timeout(),
+                poll_ref :: reference(),
+                set :: revault_dirmon_poll:set()}).
+
+%%%%%%%%%%%%%%%%%%
+%%% PUBLIC API %%%
+%%%%%%%%%%%%%%%%%%
+start_link(Name, Opts) ->
+    gen_server:start_link({via, gproc, {n, l, Name}}, ?MODULE,
+                          Opts#{name => Name}, []).
+
+force_scan(Name, Wait) ->
+    gen_server:call({via, gproc, {n, l, Name}}, force_scan, Wait).
+
+stop(Name) ->
+    gen_server:stop({via, gproc, {n, l, Name}}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% GEN_SERVER CALLBACKS %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+init(#{directory := Dir, poll_interval := Time, name := Name}) ->
+    Ref = erlang:start_timer(Time, self(), poll),
+    {ok, #state{name = Name,
+                directory = Dir,
+                poll_delay = Time,
+                poll_ref = Ref,
+                set = revault_dirmon_poll:scan(Dir)}}.
+
+handle_call(force_scan, _From, S=#state{name=Name, directory=Dir, set=Set}) ->
+    {Updates, NewSet} = revault_dirmon_poll:rescan(Dir, Set),
+    send_events(Name, Updates),
+    {reply, ok, S#state{set = NewSet}};
+handle_call(_, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info({timeout, TRef, poll}, S=#state{name=Name, directory=Dir, set=Set,
+                                            poll_delay=Time, poll_ref=TRef}) ->
+    {Updates, NewSet} = revault_dirmon_poll:rescan(Dir, Set),
+    send_events(Name, Updates),
+    NewRef = erlang:start_timer(Time, self(), poll),
+    {noreply, S#state{poll_ref=NewRef, set=NewSet}};
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+send_events(Name, {Del, Add, Mod}) ->
+    [gproc:send({p, l, Name}, make_event(Name, {deleted, D})) || D <- Del],
+    [gproc:send({p, l, Name}, make_event(Name, {added, A})) || A <- Add],
+    [gproc:send({p, l, Name}, make_event(Name, {changed, C})) || C <- Mod],
+    ok.
+
+make_event(Name, Event) -> {dirmon, Name, Event}.

--- a/apps/revault/src/revault_dirmon_poll.erl
+++ b/apps/revault/src/revault_dirmon_poll.erl
@@ -1,12 +1,61 @@
 -module(revault_dirmon_poll).
--export([scan/1]).
+-export([scan/1, rescan/2]).
 
+-ifdef(TEST).
+-export([diff_set/2]).
+-endif.
+
+%%%%%%%%%%%%%%
+%%% PUBLIC %%%
+%%%%%%%%%%%%%%
+
+%% @doc Initial scan of a directory. Returns all the found filenames
+%% along with their SHA256 value. The returned value is sorted.
+-spec scan(file:filename()) -> [{file:filename(), binary()}].
 scan(Dir) ->
-    filelib:fold_files(
+    lists:sort(filelib:fold_files(
       Dir, ".*", true,
       fun(File, Acc) ->
          {ok, Bin} = file:read_file(File),
          Hash = crypto:hash(sha256, Bin),
          [{File, Hash} | Acc]
       end, []
-    ).
+    )).
+
+%% @doc Repeat the scan of a directory from a previously known set.
+%% Returns a 2-tuple. The first element is a triple containing
+%% `{DeletedFiles, AddedFiles, ModifiedFiles}', and the second element
+%% is the new set of all found filenames along with their SHA256 value.
+%% Assumes the input set is sorted, and similarly returns sorted lists.
+-spec rescan(file:filename(), [{file:filename(), binary()}]) ->
+    {{Deleted, Added, Modified}, HashSet} when
+      Deleted :: HashSet,
+      Added :: HashSet,
+      Modified :: HashSet,
+      HashSet :: [{file:filename(), binary()}].
+rescan(Dir, OldSet) ->
+    NewSet = scan(Dir),
+    {diff_set(OldSet, NewSet), NewSet}.
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+diff_set(Old, New) ->
+    diff_set(Old, New, {[], [], []}).
+
+diff_set([], New, {Deleted, Added, Modified}) ->
+    {lists:reverse(Deleted),
+     lists:reverse(Added, New),
+     lists:reverse(Modified)};
+diff_set(Old, [], {Deleted, Added, Modified}) ->
+    {lists:reverse(Deleted, Old),
+     lists:reverse(Added),
+     lists:reverse(Modified)};
+diff_set([X|Old], [X|New], Acc) ->
+    diff_set(Old, New, Acc);
+diff_set([{F, _}|Old], [{F, _}=Changed|New], {Deleted, Added, Modified}) ->
+    diff_set(Old, New, {Deleted, Added, [Changed|Modified]});
+diff_set([O|Old], [N|New], {Deleted, Added, Modified}) ->
+    if O < N -> diff_set(Old, [N|New], {[O|Deleted], Added, Modified})
+     ; O > N -> diff_set([O|Old], New, {Deleted, [N|Added], Modified})
+    end.

--- a/apps/revault/src/revault_dirmon_poll.erl
+++ b/apps/revault/src/revault_dirmon_poll.erl
@@ -1,0 +1,12 @@
+-module(revault_dirmon_poll).
+-export([scan/1]).
+
+scan(Dir) ->
+    filelib:fold_files(
+      Dir, ".*", true,
+      fun(File, Acc) ->
+         {ok, Bin} = file:read_file(File),
+         Hash = crypto:hash(sha256, Bin),
+         [{File, Hash} | Acc]
+      end, []
+    ).

--- a/apps/revault/src/revault_dirmon_poll.erl
+++ b/apps/revault/src/revault_dirmon_poll.erl
@@ -1,6 +1,10 @@
 -module(revault_dirmon_poll).
 -export([scan/1, rescan/2]).
 
+-type hash() :: binary().
+-type set() :: [{file:filename(), hash()}].
+-export_type([set/0]).
+
 -ifdef(TEST).
 -export([diff_set/2]).
 -endif.
@@ -11,7 +15,7 @@
 
 %% @doc Initial scan of a directory. Returns all the found filenames
 %% along with their SHA256 value. The returned value is sorted.
--spec scan(file:filename()) -> [{file:filename(), binary()}].
+-spec scan(file:filename()) -> set().
 scan(Dir) ->
     lists:sort(filelib:fold_files(
       Dir, ".*", true,
@@ -27,12 +31,12 @@ scan(Dir) ->
 %% `{DeletedFiles, AddedFiles, ModifiedFiles}', and the second element
 %% is the new set of all found filenames along with their SHA256 value.
 %% Assumes the input set is sorted, and similarly returns sorted lists.
--spec rescan(file:filename(), [{file:filename(), binary()}]) ->
+-spec rescan(file:filename(), set()) ->
     {{Deleted, Added, Modified}, HashSet} when
       Deleted :: HashSet,
       Added :: HashSet,
       Modified :: HashSet,
-      HashSet :: [{file:filename(), binary()}].
+      HashSet :: set().
 rescan(Dir, OldSet) ->
     NewSet = scan(Dir),
     {diff_set(OldSet, NewSet), NewSet}.

--- a/apps/revault/test/dirmon_event_SUITE.erl
+++ b/apps/revault/test/dirmon_event_SUITE.erl
@@ -1,0 +1,82 @@
+-module(dirmon_event_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile(export_all).
+
+all() ->
+    [scan_with_timeouts, survive_unexpected_msgs].
+
+init_per_testcase(_, Config) ->
+    {ok, Apps} = application:ensure_all_started(gproc),
+    [{apps, Apps} | Config].
+
+end_per_testcase(_, Config) ->
+    [application:stop(App) || App <- ?config(apps, Config)],
+    Config.
+
+scan_with_timeouts() ->
+    [{doc, "validate that the scan is done at regular intervals based "
+           "on timeouts, and that events are sent for each discovered "
+           "file. Don't re-check the diff logic, which is already "
+           "covered in property testing suites."}].
+scan_with_timeouts(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    File = filename:join(PrivDir, "a-file.txt"),
+    gproc:reg({p, l, {?MODULE, ?FUNCTION_NAME}}),
+    {ok, _} = revault_dirmon_event:start_link(
+      {?MODULE, ?FUNCTION_NAME},
+      #{directory => PrivDir, poll_interval => 10}
+    ),
+    ok = file:write_file(File, "text"),
+    H0 = receive
+        {dirmon, {?MODULE, ?FUNCTION_NAME}, {added, {File, Hash0}}} -> Hash0
+    after 5000 ->
+        flush_err()
+    end,
+    ok = file:write_file(File, "text2"),
+    H1 = receive
+        {dirmon, {?MODULE, ?FUNCTION_NAME}, {changed, {File, Hash1}}} -> Hash1
+    after 5000 ->
+        flush_err()
+    end,
+    ok = file:delete(File),
+    receive
+        {dirmon, {?MODULE, ?FUNCTION_NAME}, {deleted, {File, H1}}} -> ok
+    after 5000 ->
+        flush_err()
+    end,
+    ?assertNotEqual(H0, H1),
+    ok.
+
+survive_unexpected_msgs() ->
+    [{doc, "Just make sure that unexpected calls or messages don't kill "
+           "the server as it is important."}].
+survive_unexpected_msgs(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    {ok, Pid} = revault_dirmon_event:start_link(
+      {?MODULE, ?FUNCTION_NAME},
+      #{directory => PrivDir, poll_interval => 1000000}
+    ),
+    Pid ! make_ref(),
+    gen_server:cast(Pid, make_ref()),
+    try
+        gen_server:call(Pid, make_ref(), 100), % don't take too long
+        error(no_response_expected)
+    catch
+        exit:{timeout, _} ->
+            ok
+    end,
+    ?assert(is_process_alive(Pid)),
+    ok.
+
+%%%%%%%%%%%%%%%
+%%% HELPERS %%%
+%%%%%%%%%%%%%%%
+flush_err() ->
+    receive
+        X ->
+            ct:pal("message: ~p", [X]),
+            flush_err()
+    after 0 ->
+        error(no_event)
+    end.

--- a/apps/revault/test/prop_dirmon_event_statem.erl
+++ b/apps/revault/test/prop_dirmon_event_statem.erl
@@ -1,0 +1,242 @@
+-module(prop_dirmon_event_statem).
+-include_lib("proper/include/proper.hrl").
+-define(DIR, "_build/test/scratch").
+-define(LISTENER_NAME, {?MODULE, ?DIR}).
+-compile(export_all).
+
+%% Model Callbacks
+-export([command/1, initial_state/0, next_state/3,
+         precondition/2, postcondition/3]).
+
+%%%%%%%%%%%%%%%%%%
+%%% PROPERTIES %%%
+%%%%%%%%%%%%%%%%%%
+prop_test(doc) ->
+   "files are added, changed, and removed, and the model checks that between "
+   "any two scans, the data discovered on disk matches what the operation "
+   "logically does when the disk is abstracted, and is forwarded as events".
+prop_test() ->
+    ?SETUP(fun() ->
+        {ok, Apps} = application:ensure_all_started(gproc),
+        fun() ->
+             [application:stop(App) || App <- Apps],
+             revault_test_utils:teardown_scratch_dir(?DIR) % safety
+        end
+    end,
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                revault_test_utils:setup_scratch_dir(?DIR),
+                {ok, _} = revault_dirmon_event:start_link(
+                    ?LISTENER_NAME,
+                    #{directory => ?DIR,
+                      poll_interval => 6000000} % too long to interfere
+                ),
+                Listener = spawn_link(fun listener/0),
+                {History, State, Result} = run_commands(?MODULE, Cmds),
+                Listener ! stop,
+                revault_dirmon_event:stop(?LISTENER_NAME),
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                ?WHENFAIL(io:format("History: ~p\nState: ~p\nResult: ~p\n",
+                                    [History,State,Result]),
+                          aggregate(command_names(Cmds), Result =:= ok))
+            end)).
+
+%%%%%%%%%%%%%
+%%% MODEL %%%
+%%%%%%%%%%%%%
+%% @doc Initial model value at system start. Should be deterministic.
+initial_state() ->
+    #{set => #{},
+      ops => [],
+      dirs => []}.
+
+%% @doc List of possible commands to run against the system
+command(State) ->
+    Calls = [
+        {call, ?MODULE, add_file, [new_filename(State), contents()]},
+        {call, ?MODULE, wait_events, []}
+    ]
+    ++ case maps:size(State) of
+        3 -> % the two static atom keys
+            [];
+        _ ->
+            [{call, ?MODULE, change_file, [filename(State), contents()]},
+             {call, ?MODULE, delete_file, [filename(State)]}]
+    end,
+    oneof(Calls).
+
+%% @doc Determines whether a command should be valid under the
+%% current state.
+precondition(State, {call, _, add_file, [Filename, _Contents]}) ->
+    not maps:is_key(Filename, State);
+precondition(State, {call, _, change_file, [Filename, Contents]}) ->
+    case maps:find(Filename, State) of
+        error ->
+            false;
+        {ok, {_Hash, Contents}} ->
+            false;
+        {ok, {_Hash, _OldContents}} ->
+            true
+    end;
+precondition(State, {call, _, delete_file, [Filename]}) ->
+    maps:is_key(Filename, State);
+precondition(_State, {call, _Mod, _Fun, _Args}) ->
+    true.
+
+%% @doc Given the state `State' *prior* to the call
+%% `{call, Mod, Fun, Args}', determine whether the result
+%% `Res' (coming from the actual system) makes sense.
+postcondition(_State, {call, _, add_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, change_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, delete_file, _}, ok) ->
+    true;
+postcondition(State, {call, _, wait_events, []}, Ret) ->
+    {ExpDel, ExpAdd, ExpMod} = merge_ops(
+        [{Op, {filename:join(F),H}} || {Op, {F,H}} <- maps:get(ops, State)],
+        maps:get(set, State)
+    ),
+    Res = {ExpDel, ExpAdd, ExpMod} =:= Ret,
+    Res orelse io:format("===~n~p~n---~n~p~n===~n",
+                         [{ExpDel, ExpAdd, ExpMod}, Ret]),
+    Res;
+postcondition(_State, {call, _Mod, _Fun, _Args}, _Res) ->
+    false.
+
+%% @doc Assuming the postcondition for a call was true, update the model
+%% accordingly for the test to proceed.
+next_state(State, _Res, {call, _, add_file, [FileName, Contents]}) ->
+    Hash = crypto:hash(sha256, Contents),
+    Dirs = maps:get(dirs, State),
+    Path = lists:droplast(FileName),
+    State#{FileName => {Hash, Contents},
+           dirs => lists:usort([Path|Dirs])--[[]],
+           ops => [{add, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, {call, _, change_file, [FileName, Contents]}) ->
+    Hash = crypto:hash(sha256, Contents),
+    State#{FileName => {Hash, Contents},
+           ops => [{change, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, {call, _, delete_file, [FileName]}) ->
+    {Hash, _} = maps:get(FileName, State),
+    NewState = maps:remove(FileName, State),
+    NewState#{ops => [{delete, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, {call, _, wait_events, []}) ->
+    #{set := OldSet, ops := Ops} = State,
+    MergedOps = merge_ops([{Op, {filename:join(F),H}} || {Op, {F,H}} <- Ops],
+                          OldSet),
+    State#{set := apply_ops(MergedOps, OldSet),
+           ops => []};
+next_state(State, _Res, {call, _Mod, _Fun, _Args}) ->
+    NewState = State,
+    NewState.
+
+%%%%%%%%%%%%%%%%%%
+%%% GENERATORS %%%
+%%%%%%%%%%%%%%%%%%
+new_filename(Map) ->
+    ?SUCHTHAT(
+       Path,
+       ?LET(Base, revault_test_utils:gen_path(),
+            filename:split(filename:join(?DIR, Base))),
+       lists:all(
+         fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
+         maps:get(dirs, Map)
+       )
+       andalso
+       lists:all(
+         fun(Existing) -> not lists:prefix(Existing, Path) end,
+         [K || K <- maps:keys(Map), not is_atom(K)]
+       )
+    ).
+
+filename(Map) ->
+    oneof([P || P <- maps:keys(Map), not is_atom(P)]).
+
+contents() ->
+    binary().
+
+%%%%%%%%%%%%%%%%%%%
+%%% MODEL CALLS %%%
+%%%%%%%%%%%%%%%%%%%
+add_file(FileName, Contents) ->
+    Path = filename:join(FileName),
+    filelib:ensure_dir(Path),
+    file:write_file(Path, Contents, [sync, raw]).
+
+change_file(FileName, Contents) ->
+    file:write_file(filename:join(FileName), Contents, [sync, raw]).
+
+delete_file(FileName) ->
+    file:delete(filename:join(FileName)).
+
+wait_events() ->
+    ok = revault_dirmon_event:force_scan(?LISTENER_NAME, 5000), % sync call
+    Ref = make_ref(),
+    ?MODULE ! {read, self(), Ref},
+    receive
+        {Ref, Resp} -> Resp
+    end.
+
+%%%%%%%%%%%%%%%
+%%% HELPERS %%%
+%%%%%%%%%%%%%%%
+merge_ops(Ops, InitSet) ->
+    Map = maps:from_list([{File, {Op, Hash}}
+                          || {Op, {File, Hash}} <- lists:reverse(Ops)]),
+    process_ops(Map, InitSet).
+
+process_ops(Map, InitSet) ->
+    {Del, Add, Mod} = maps:fold(
+        fun(File, Ops, {Del, Add, Mod}) ->
+            Init = maps:get(File, InitSet, undefined),
+            case {Ops, Init} of
+                %% unchanged over both polls
+                {{delete, _Hash}, undefined} ->
+                    {Del, Add, Mod};
+                %% deleted file
+                {{delete, _Hash}, OldHash} ->
+                    {[{File, OldHash}|Del], Add, Mod};
+                %% sequence ended in added file
+                {{_, Hash}, undefined} ->
+                    {Del, [{File, Hash}|Add], Mod};
+                %% changes had no impact
+                {{_, Hash}, Hash} ->
+                    {Del, Add, Mod};
+                %% sequence ended in changed file
+                {{_, Hash}, _} ->
+                    {Del, Add, [{File, Hash}|Mod]}
+            end
+        end,
+        {[], [], []},
+        Map
+    ),
+    {lists:sort(Del), lists:sort(Add), lists:sort(Mod)}.
+
+apply_ops({Del, Add, Mod}, Map) ->
+    maps:merge(
+      lists:foldl(fun({K,_V}, M) -> maps:remove(K, M) end, Map, Del),
+      maps:merge(maps:from_list(Add), maps:from_list(Mod))
+    ).
+
+listener() ->
+    register(?MODULE, self()),
+    true = gproc:reg({p, l, ?LISTENER_NAME}),
+    listener([], [], []).
+
+listener(Del, Add, Mod) ->
+    receive
+        {dirmon, ?LISTENER_NAME, Event} ->
+            case Event of
+                {deleted, Entry} -> listener([Entry|Del], Add, Mod);
+                {added, Entry} -> listener(Del, [Entry|Add], Mod);
+                {changed, Entry} -> listener(Del, Add, [Entry|Mod])
+            end;
+        {read, Pid, Ref} ->
+            Pid ! {Ref, {lists:sort(Del), lists:sort(Add), lists:sort(Mod)}},
+            listener([], [], []);
+        stop ->
+            unregister(?MODULE),
+            ok
+    end.

--- a/apps/revault/test/prop_dirmon_event_statem.erl
+++ b/apps/revault/test/prop_dirmon_event_statem.erl
@@ -69,7 +69,7 @@ command(State) ->
 %% @doc Determines whether a command should be valid under the
 %% current state.
 precondition(State, {call, _, add_file, [Filename, _Contents]}) ->
-    not maps:is_key(Filename, State);
+    not maps:is_key(Filename, State) andalso not_is_dir(Filename, State);
 precondition(State, {call, _, change_file, [Filename, Contents]}) ->
     case maps:find(Filename, State) of
         error ->
@@ -140,19 +140,23 @@ new_filename(Map) ->
        Path,
        ?LET(Base, revault_test_utils:gen_path(),
             filename:split(filename:join(?DIR, Base))),
-       lists:all(
-         fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
-         maps:get(dirs, Map)
-       )
-       andalso
-       lists:all(
-         fun(Existing) -> not lists:prefix(Existing, Path) end,
-         [K || K <- maps:keys(Map), not is_atom(K)]
-       )
+       not_is_dir(Path, Map)
     ).
 
 filename(Map) ->
     oneof([P || P <- maps:keys(Map), not is_atom(P)]).
+
+not_is_dir(Path, Map) ->
+    lists:all(
+      fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
+      maps:get(dirs, Map)
+     )
+    andalso
+    lists:all(
+      fun(Existing) -> not lists:prefix(Existing, Path) end,
+      [K || K <- maps:keys(Map), not is_atom(K)]
+     ).
+
 
 contents() ->
     binary().

--- a/apps/revault/test/prop_dirmon_poll.erl
+++ b/apps/revault/test/prop_dirmon_poll.erl
@@ -1,0 +1,54 @@
+-module(prop_dirmon_poll).
+-compile(export_all).
+-include_lib("proper/include/proper.hrl").
+
+prop_detect(doc) ->
+    "Create a set of files and make sure that the scanner can find "
+    "all of them".
+%% - setup directory
+%% - ensure the whole list of directories and files can be found
+%%   - give a hash for each file (sha256?)
+%% - apply changes
+%% - ensure changes are found
+%%   - new files, changed files, dropped files
+%% - clean up directory
+prop_detect() ->
+    Dir = revault_test_utils:scratch_dir_name(),
+    ?SETUP(fun() ->
+        revault_test_utils:setup_scratch_dir(Dir),
+        fun() -> revault_test_utils:teardown_scratch_dir(Dir) end
+    end,
+    ?FORALL({Files, Ops}, populate_dir(Dir),
+      begin
+        revault_test_utils:setup_scratch_dir(Dir),
+        eval(Ops),
+        Found = revault_dirmon_poll:scan(Dir),
+        revault_test_utils:teardown_scratch_dir(Dir),
+        ?WHENFAIL(io:format("Expected: ~tp~n"
+                            "Found: ~tp~n", [Files, Found]),
+                  lists:usort(Files) == lists:sort(Found))
+      end
+    )).
+
+populate_dir(Base) ->
+    ?LET(Pairs, list(make_file(Base)), 
+         begin
+             %% Drop a file that's also a path of another one
+             ValidPairs = [P || P = {{Path,_}, _} <- Pairs,
+                                not is_dir(filename:split(Path), Pairs)],
+             lists:unzip(ValidPairs)
+         end).
+
+is_dir(_Path, []) -> false;
+is_dir(Path, [{{Candidate,_},_}|Rest]) ->
+    Dir = lists:droplast(filename:split(Candidate)),
+    lists:prefix(Path, Dir) orelse is_dir(Path, Rest).
+
+make_file(Base) ->
+    Name = revault_test_utils:gen_path(),
+    Content = binary(),
+    Path = ?LET(N, Name, filename:join(Base, N)),
+    ?LET({P,C}, {Path, Content},
+         {{P, crypto:hash(sha256, C)},
+           [{'call', filelib, ensure_dir, [P]},
+              {'call', file, write_file, [P, C]}]}).

--- a/apps/revault/test/prop_dirmon_poll.erl
+++ b/apps/revault/test/prop_dirmon_poll.erl
@@ -2,18 +2,17 @@
 -compile(export_all).
 -include_lib("proper/include/proper.hrl").
 
-prop_detect(doc) ->
+prop_first_scan(doc) ->
     "Create a set of files and make sure that the scanner can find "
     "all of them".
 %% - setup directory
 %% - ensure the whole list of directories and files can be found
 %%   - give a hash for each file (sha256?)
-%% - apply changes
-%% - ensure changes are found
-%%   - new files, changed files, dropped files
 %% - clean up directory
-prop_detect() ->
+prop_first_scan() ->
     Dir = revault_test_utils:scratch_dir_name(),
+    %% Use ?SETUP(...) to ensure the directory is cleaned up
+    %% even on failing runs
     ?SETUP(fun() ->
         revault_test_utils:setup_scratch_dir(Dir),
         fun() -> revault_test_utils:teardown_scratch_dir(Dir) end
@@ -21,7 +20,7 @@ prop_detect() ->
     ?FORALL({Files, Ops}, populate_dir(Dir),
       begin
         revault_test_utils:setup_scratch_dir(Dir),
-        eval(Ops),
+        run_ops(Ops),
         Found = revault_dirmon_poll:scan(Dir),
         revault_test_utils:teardown_scratch_dir(Dir),
         ?WHENFAIL(io:format("Expected: ~tp~n"
@@ -30,14 +29,31 @@ prop_detect() ->
       end
     )).
 
+prop_diff_set(doc) ->
+    "Test the internal function that does diffing of subsets of "
+    "files to find what changed over time.".
+prop_diff_set() ->
+    ?FORALL({Base, Add, Del, Change, End}, hash_gen(),
+      begin
+          {D, A, M} = revault_dirmon_poll:diff_set(Base, End),
+          ?WHENFAIL(
+             io:format("~p vs ~p~n", [{Add,Del,Change}, {D,A,M}]),
+             D == Del andalso A == Add andalso M == Change
+          )
+      end).
+
+%%%%%%%%%%%%%%%%%%
+%%% GENERATORS %%%
+%%%%%%%%%%%%%%%%%%
 populate_dir(Base) ->
-    ?LET(Pairs, list(make_file(Base)), 
+    ?LET(Pairs, list(make_file(Base)),
          begin
              %% Drop a file that's also a path of another one
              ValidPairs = [P || P = {{Path,_}, _} <- Pairs,
                                 not is_dir(filename:split(Path), Pairs)],
              lists:unzip(ValidPairs)
          end).
+
 
 is_dir(_Path, []) -> false;
 is_dir(Path, [{{Candidate,_},_}|Rest]) ->
@@ -50,5 +66,38 @@ make_file(Base) ->
     Path = ?LET(N, Name, filename:join(Base, N)),
     ?LET({P,C}, {Path, Content},
          {{P, crypto:hash(sha256, C)},
-           [{'call', filelib, ensure_dir, [P]},
-              {'call', file, write_file, [P, C]}]}).
+           [{call, filelib, ensure_dir, [P]},
+            {call, file, write_file, [P, C, [sync]]}]}).
+
+run_ops(Ops) ->
+    Res = eval(Ops),
+    Res.
+
+hash_gen() ->
+    KeyGen = ?LET(Ks, non_empty(list(string())), lists:usort(Ks)),
+    HashGen = ?LET(Ks, KeyGen, [{K, binary()} || K <- Ks]),
+    ?LET(End, HashGen,
+      ?LET(TmpAdded, list(oneof(End)),
+        begin
+          Added = lists:usort(TmpAdded),
+          case End -- Added of
+            [] ->
+                {[], Added, [], [], End};
+            Tmp1 ->
+                ?LET(TmpChanged, list(oneof(Tmp1)),
+                 begin
+                    Changed = lists:usort(TmpChanged),
+                    Init = [case lists:member({K,B}, Changed) of
+                                true -> {K, <<1, B/binary>>};
+                                false -> {K, B}
+                            end || {K,B} <- Tmp1],
+                    ?LET(TmpDel, HashGen,
+                      begin
+                        Del = [{K, B} || {K, B} <- TmpDel,
+                                         false == lists:keyfind(K, 1, End)],
+                        {lists:sort(Init++Del), Added, Del, Changed, End}
+                      end)
+                 end)
+          end
+       end)
+    ).

--- a/apps/revault/test/prop_dirmon_poll_statem.erl
+++ b/apps/revault/test/prop_dirmon_poll_statem.erl
@@ -1,0 +1,195 @@
+-module(prop_dirmon_poll_statem).
+-include_lib("proper/include/proper.hrl").
+-define(DIR, "_build/test/scratch").
+-compile(export_all).
+
+%% Model Callbacks
+-export([command/1, initial_state/0, next_state/3,
+         precondition/2, postcondition/3]).
+
+%%%%%%%%%%%%%%%%%%
+%%% PROPERTIES %%%
+%%%%%%%%%%%%%%%%%%
+prop_test(doc) ->
+   "files are added, changed, and removed, and the model checks that between "
+   "any two scans, the data discovered on disk matches what the operation "
+   "logically does when the disk is abstracted.".
+prop_test() ->
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                revault_test_utils:setup_scratch_dir(?DIR),
+                {History, State, Result} = run_commands(?MODULE, Cmds),
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                ?WHENFAIL(io:format("History: ~p\nState: ~p\nResult: ~p\n",
+                                    [History,State,Result]),
+                          aggregate(command_names(Cmds), Result =:= ok))
+            end).
+
+%%%%%%%%%%%%%
+%%% MODEL %%%
+%%%%%%%%%%%%%
+%% @doc Initial model value at system start. Should be deterministic.
+initial_state() ->
+    #{set => [],
+      ops => [],
+      dirs => []}.
+
+%% @doc List of possible commands to run against the system
+command(State) ->
+    Calls = [
+        {call, ?MODULE, add_file, [new_filename(State), contents()]},
+        {call, revault_dirmon_poll, rescan, [?DIR, maps:get(set, State)]}
+    ]
+    ++ case maps:size(State) of
+        3 -> % the two static atom keys
+            [];
+        _ ->
+            [{call, ?MODULE, change_file, [filename(State), contents()]},
+             {call, ?MODULE, delete_file, [filename(State)]}]
+    end,
+    oneof(Calls).
+
+%% @doc Determines whether a command should be valid under the
+%% current state.
+precondition(State, {call, _, add_file, [Filename, _Contents]}) ->
+    not maps:is_key(Filename, State);
+precondition(State, {call, _, change_file, [Filename, Contents]}) ->
+    case maps:find(Filename, State) of
+        error ->
+            false;
+        {ok, {_Hash, Contents}} ->
+            false;
+        {ok, {_Hash, _OldContents}} ->
+            true
+    end;
+precondition(State, {call, _, delete_file, [Filename]}) ->
+    maps:is_key(Filename, State);
+precondition(_State, {call, _Mod, _Fun, _Args}) ->
+    true.
+
+%% @doc Given the state `State' *prior* to the call
+%% `{call, Mod, Fun, Args}', determine whether the result
+%% `Res' (coming from the actual system) makes sense.
+postcondition(_State, {call, _, add_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, change_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, delete_file, _}, ok) ->
+    true;
+postcondition(State, {call, _, rescan, [_, _]}, Ret) ->
+    {ExpDel, ExpAdd, ExpMod} = merge_ops(
+        [{Op, {filename:join(F),H}} || {Op, {F,H}} <- maps:get(ops, State)],
+        maps:get(set, State)
+    ),
+    ExpSet = lists:sort(
+        [{filename:join(File), Hash}
+         || {File, {Hash, _}} <- maps:to_list(State), not is_atom(File)]
+    ),
+    Res = {{ExpDel, ExpAdd, ExpMod}, ExpSet} =:= Ret,
+    Res orelse io:format("===~n~p~n---~n~p~n===~n",
+                         [{{ExpDel, ExpAdd, ExpMod}, ExpSet}, Ret]),
+    Res;
+postcondition(_State, {call, _Mod, _Fun, _Args}, _Res) ->
+    false.
+
+%% @doc Assuming the postcondition for a call was true, update the model
+%% accordingly for the test to proceed.
+next_state(State, _Res, {call, _, add_file, [FileName, Contents]}) ->
+    Hash = crypto:hash(sha256, Contents),
+    Dirs = maps:get(dirs, State),
+    Path = lists:droplast(FileName),
+    State#{FileName => {Hash, Contents},
+           dirs => lists:usort([Path|Dirs])--[[]],
+           ops => [{add, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, {call, _, change_file, [FileName, Contents]}) ->
+    Hash = crypto:hash(sha256, Contents),
+    State#{FileName => {Hash, Contents},
+           ops => [{change, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, {call, _, delete_file, [FileName]}) ->
+    {Hash, _} = maps:get(FileName, State),
+    NewState = maps:remove(FileName, State),
+    NewState#{ops => [{delete, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, Res, {call, _, rescan, [_, _]}) ->
+    %% Symbolic call to work around the symbolic execution issues
+    %% without having to wrap the rescan calls furthermore.
+    State#{set := {call, erlang, element, [2, Res]},
+           ops => []};
+next_state(State, _Res, {call, _Mod, _Fun, _Args}) ->
+    NewState = State,
+    NewState.
+
+%%%%%%%%%%%%%%%%%%
+%%% GENERATORS %%%
+%%%%%%%%%%%%%%%%%%
+new_filename(Map) ->
+    ?SUCHTHAT(
+       Path,
+       ?LET(Base, revault_test_utils:gen_path(),
+            filename:split(filename:join(?DIR, Base))),
+       lists:all(
+         fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
+         maps:get(dirs, Map)
+       )
+       andalso
+       lists:all(
+         fun(Existing) -> not lists:prefix(Existing, Path) end,
+         [K || K <- maps:keys(Map), not is_atom(K)]
+       )
+    ).
+
+filename(Map) ->
+    oneof([P || P <- maps:keys(Map), not is_atom(P)]).
+
+contents() ->
+    binary().
+
+%%%%%%%%%%%%%%%%%%%
+%%% MODEL CALLS %%%
+%%%%%%%%%%%%%%%%%%%
+add_file(FileName, Contents) ->
+    Path = filename:join(FileName),
+    filelib:ensure_dir(Path),
+    file:write_file(Path, Contents, [sync, raw]).
+
+change_file(FileName, Contents) ->
+    file:write_file(filename:join(FileName), Contents, [sync, raw]).
+
+delete_file(FileName) ->
+    file:delete(filename:join(FileName)).
+
+%%%%%%%%%%%%%%%
+%%% HELPERS %%%
+%%%%%%%%%%%%%%%
+merge_ops(Ops, InitSet) ->
+    Map = maps:from_list([{File, {Op, Hash}}
+                          || {Op, {File, Hash}} <- lists:reverse(Ops)]),
+    process_ops(Map, InitSet).
+
+process_ops(Map, InitSet) ->
+    {Del, Add, Mod} = maps:fold(
+        fun(File, Ops, {Del, Add, Mod}) ->
+            Init = proplists:get_value(File, InitSet),
+            case {Ops, Init} of
+                %% unchanged over both polls
+                {{delete, _Hash}, undefined} ->
+                    {Del, Add, Mod};
+                %% deleted file
+                {{delete, _Hash}, OldHash} ->
+                    {[{File, OldHash}|Del], Add, Mod};
+                %% sequence ended in added file
+                {{_, Hash}, undefined} ->
+                    {Del, [{File, Hash}|Add], Mod};
+                %% changes had no impact
+                {{_, Hash}, Hash} ->
+                    {Del, Add, Mod};
+                %% sequence ended in changed file
+                {{_, Hash}, _} ->
+                    {Del, Add, [{File, Hash}|Mod]}
+            end
+        end,
+        {[], [], []},
+        Map
+    ),
+    {lists:sort(Del), lists:sort(Add), lists:sort(Mod)}.
+

--- a/apps/revault/test/prop_dirmon_poll_statem.erl
+++ b/apps/revault/test/prop_dirmon_poll_statem.erl
@@ -53,7 +53,7 @@ command(State) ->
 %% @doc Determines whether a command should be valid under the
 %% current state.
 precondition(State, {call, _, add_file, [Filename, _Contents]}) ->
-    not maps:is_key(Filename, State);
+    not maps:is_key(Filename, State) andalso not_is_dir(Filename, State);
 precondition(State, {call, _, change_file, [Filename, Contents]}) ->
     case maps:find(Filename, State) of
         error ->
@@ -127,15 +127,18 @@ new_filename(Map) ->
        Path,
        ?LET(Base, revault_test_utils:gen_path(),
             filename:split(filename:join(?DIR, Base))),
-       lists:all(
-         fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
-         maps:get(dirs, Map)
-       )
-       andalso
-       lists:all(
-         fun(Existing) -> not lists:prefix(Existing, Path) end,
-         [K || K <- maps:keys(Map), not is_atom(K)]
-       )
+       not_is_dir(Path, Map)
+    ).
+
+not_is_dir(Path, Map) ->
+    lists:all(
+        fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
+        maps:get(dirs, Map)
+    )
+    andalso
+    lists:all(
+        fun(Existing) -> not lists:prefix(Existing, Path) end,
+        [K || K <- maps:keys(Map), not is_atom(K)]
     ).
 
 filename(Map) ->

--- a/apps/revault/test/revault_test_utils.erl
+++ b/apps/revault/test/revault_test_utils.erl
@@ -1,0 +1,74 @@
+-module(revault_test_utils).
+-include_lib("proper/include/proper.hrl").
+-export([scratch_dir_name/0, setup_scratch_dir/1, teardown_scratch_dir/1]).
+-export([gen_path/0]).
+
+%%%%%%%%%%%%%%%%%%%%%%
+%%% UTIL FUNCTIONS %%%
+%%%%%%%%%%%%%%%%%%%%%%
+scratch_dir_name() ->
+    T = erlang:monotonic_time(),
+    C = erlang:unique_integer([positive, monotonic]),
+    Name = integer_to_list(T) ++ "_" ++ integer_to_list(C),
+    filename:join(["_build", "test", "scratch", Name]).
+
+setup_scratch_dir(Dir) ->
+    filelib:ensure_dir(filename:join([Dir, ".touch"])),
+    Dir.
+
+teardown_scratch_dir(Dir) ->
+    AllDirs = filelib:fold_files(
+        Dir, ".*", true,
+        fun(File, Acc) ->
+            file:delete(File),
+            [filename:dirname(File) | Acc]
+        end, []),
+    Dirs = lists:usort(lists:append(
+        [all_paths(drop_file_prefix(Dir, D)) || D <- lists:usort(AllDirs)]
+    )),
+    _ = [file:del_dir(filename:join(Dir, D)) || D <- lists:reverse(Dirs)],
+    file:del_dir(Dir),
+    ok.
+
+%%%%%%%%%%%%%%%%%%
+%%% GENERATORS %%%
+%%%%%%%%%%%%%%%%%%
+gen_path() ->
+    ?SUCHTHAT(
+       Path,
+       ?LET(Frags, gen_filename(),
+            filename:join(Frags)),
+       byte_size(unicode:characters_to_binary(Path)) < 256
+    ).
+
+gen_filename() ->
+    non_empty(list(gen_filename_part())).
+
+gen_filename_part() ->
+    ?LET(B, non_empty(path_chars()), unicode:characters_to_list(B)).
+
+path_chars() ->
+    list(oneof([
+        range($0,$9), range($a,$z), range($A, $Z),
+        oneof(" &%!'\":;^"),
+        range(16#1F600, 16#1F64F)
+    ])).
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+drop_file_prefix(Dir, Path) ->
+    drop_file_prefix_(filename:split(Dir), filename:split(Path)).
+
+drop_file_prefix_([X|As], [X|Bs]) -> drop_file_prefix_(As, Bs);
+drop_file_prefix_(_, []) -> [];
+drop_file_prefix_(_, Rest) -> filename:join(Rest).
+
+all_paths(Path) ->
+    all_paths(filename:split(Path), []).
+
+all_paths([], Acc) -> Acc;
+all_paths([H|T], []) -> all_paths(T, [H]);
+all_paths([H|T], [P|Ps]) ->
+    all_paths(T, [filename:join(P,H), P | Ps]).
+

--- a/rebar.config
+++ b/rebar.config
@@ -5,9 +5,13 @@
     ]}
 ]}.
 
+{deps, [
+    gproc,
+    recon
+]}.
+
 {erl_opts, [debug_info]}.
 {ct_opts, [{ct_hooks, [cth_surefire]}]}.
-{deps, []}.
 
 {project_plugins, [
     rebar3_lint,

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,12 @@
 ]}.
 
 {erl_opts, [debug_info]}.
-{ct_opts, [{ct_hooks, [cth_surefire]}]}.
+{ct_opts, [
+    %% for CI
+    {ct_hooks, [cth_surefire]},
+    %% we work a lot with dir scans, so one per test is a good idea
+    {create_priv_dir, auto_per_tc}
+]}.
 
 {project_plugins, [
     rebar3_lint,

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 ]}.
 
 {cover_enabled, true}.
-{cover_opts, [verbose]}.
+{cover_opts, [verbose, {min_coverage, 80}]}.
 
 {dialyzer, [
     {warnings, [
@@ -37,6 +37,10 @@
         {erl_opts, [nowarn_export_all]},
         {deps, [proper]}
     ]}
+]}.
+
+{pre_hooks, [
+    {proper, "rm -rf _build/test/scratch/"}
 ]}.
 
 {relx, [{release, {revault, "0.1.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
 {"1.1.0",
-[{<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},0}]}.
+[{<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},0},
+ {<<"recon">>,{pkg,<<"recon">>,<<"2.3.6">>},0}]}.
 [
 {pkg_hash,[
- {<<"gproc">>, <<"CEA02C578589C61E5341FCE149EA36CCEF236CC2ECAC8691FBA408E7EA77EC2F">>}]}
+ {<<"gproc">>, <<"CEA02C578589C61E5341FCE149EA36CCEF236CC2ECAC8691FBA408E7EA77EC2F">>},
+ {<<"recon">>, <<"2BCAD0CF621FB277CABBB6413159CD3AA30265C2DEE42C968697988B30108604">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,6 @@
-[].
+{"1.1.0",
+[{<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"gproc">>, <<"CEA02C578589C61E5341FCE149EA36CCEF236CC2ECAC8691FBA408E7EA77EC2F">>}]}
+].


### PR DESCRIPTION
At this point this PR only covers the basic functionality:

- scanning a directory
- scanning a directory a second time again and noting all changes by type (add/del/change) plus exposing a set for later polls
- full property tests (may need a cleanup) + 100% code coverage (so far) -- most of the complexity is in handling not accidentally re-creating a file in a directory and so on.
- tests run only on Linux and OSX so far
- only returns filenames + hashes.
- a basic interval-based poller that should be portable albeit inefficient
- allow a forced full re-scan (to build a base state from which changes are detected)
- allow all of these to be used interchangeably by plugging them in gproc properties for events

What's left to do is adding state tracking in memory to interpret whether changes are relevant. Some tracking is done right now, but it has no intelligence and can't be used for decision-making, only diffing.