### PR TITLE
Introduce directory model and rewrite statem tests to use them.

### DIFF
--- a/apps/revault/test/dirgen.erl
+++ b/apps/revault/test/dirgen.erl
@@ -4,14 +4,33 @@
 -include_lib("proper/include/proper.hrl").
 -compile(export_all).
 
+%% @doc wrapper for file operations as used by dirmodel
+%% ensures that directories are all in place for simplicity
+write_file(Path, Contents, Opts) ->
+    filelib:ensure_dir(Path),
+    file:write_file(Path, Contents, Opts).
+
+%% @doc Equivalent to {@link write_file/3}. Named differently
+%% to help with predictable models.
+change_file(Path, Contents, Opts) ->
+    write_file(Path, Contents, Opts).
+
+%% @doc wrapper for file operations as used by dirmodel
+delete_file(Path) ->
+    file:delete(Path).
+
+
 path() ->
     non_empty(list(path_chars())).
 
 path_chars() ->
-    non_empty(list(frequency([
-        {1, range($0, $9)},
-        {5, range($a, $z)},
-        {5, range($A, $Z)},
-        {1, oneof(". &%!'\":;^")},
-        {1, range(16#1F600, 16#1F64F)}
-    ]))).
+    ?SUCHTHAT(Chars,
+              non_empty(list(frequency([
+                {1, range($0, $9)},
+                {5, range($a, $z)},
+                {5, range($A, $Z)},
+                {1, oneof(". &%!'\":;^")},
+                {1, range(16#1F600, 16#1F64F)}
+              ]))),
+              %% Prevent ./ or ../ since they're relative
+              Chars =/= "." andalso Chars =/= "..").

--- a/apps/revault/test/dirgen.erl
+++ b/apps/revault/test/dirgen.erl
@@ -1,0 +1,17 @@
+%% @doc
+%% Bunch of generators that are useful to use for directory generation
+-module(dirgen).
+-include_lib("proper/include/proper.hrl").
+-compile(export_all).
+
+path() ->
+    non_empty(list(path_chars())).
+
+path_chars() ->
+    non_empty(list(frequency([
+        {1, range($0, $9)},
+        {5, range($a, $z)},
+        {5, range($A, $Z)},
+        {1, oneof(". &%!'\":;^")},
+        {1, range(16#1F600, 16#1F64F)}
+    ]))).

--- a/apps/revault/test/dirmodel.erl
+++ b/apps/revault/test/dirmodel.erl
@@ -1,0 +1,264 @@
+%%% @doc
+%%% How to generate files and ensure we don't have duplicates,
+%%% nor that we try to name files after directories.
+%%%
+%%% naive approach: just generate random paths and filenames
+%%% and filter out the bad stuff so that it works. All subsequent
+%%% generations need the content of the prior ones to know what existed
+%%% or not.
+%%%
+%%% two-step approach: generate a random directory tree based on paths.
+%%% Then, generate a random set of files that each belong to a random path
+%%% of the tree; make sure through a lookup that the current pair does not
+%%% match an existing path. All subsequent generations need the content of
+%%% the prior ones to know what existed or not.
+%%%
+%%% model-based approach: create a tree/forest data structure, where each
+%%% inner node is a directory, and each leaf is a file; at any given level,
+%%% a file can't bear the same name as an inner node.
+%%% Files are created or managed by picking a random path in the tree and
+%%% inserting data in it. The tree represents the state and can be used to
+%%% do all operations, but without caring about the filesystem.
+%%%
+%%% The advantage of the tree model is that it can be used for both stateless
+%%% and stateful tests. Additional inner node types can be added to represent
+%%% things such as symlinks (where supported), or used to create alterations
+%%% such as "case sensitive duplicates" of given paths.
+%%%
+%%% The tree model could be activated in many ways:
+%%%
+%%% 1. `apply_model(Model, Dir)', which reconciliates the filesystem
+%%%    with what the model should be.
+%%% 2. `add_new_file(Model)' or `some_change(Model)' functions, which return
+%%%    both the new model and a symbolic call of the form `{NewModel, Call}'
+%%%    which can then be used to drive more changes.
+%%% 3. `add_new_file(Model) -> SymbolicCall' and
+%%%    `apply_call(Dir, Model, SymbolicCall) -> NewModel' function pairs, which
+%%%    allows to split approach 2 in two distinct steps.
+%%%
+%%% Approach 1 is risky, because it essentially needs to manipulate the file
+%%% system as much as any app would. It is super interesting for stateless
+%%% properties and test setup, but would be useless for stateful properties
+%%% while assuming that modifications to the model take place elsewhere.
+%%%
+%%% Approach 2 is interesting from the point of view that it lets us evolve
+%%% a model, and create a zippable list of operations that can be applied,
+%%% giving the benefits of Approach 1 but without the statefulness of the
+%%% filesystem to reconcile. The problem is that it is essentially useless
+%%% for stateful properties as well since commands are generated in a way
+%%% that is distinct from their application and update in next_state as a
+%%% callback.
+%%%
+%%% Approach 3 breaks things apart; the model is fully based on a statem-like
+%%% ideal for properties, where the command can be generated from the current
+%%% state, and its application to the model is done separatedly, as it would
+%%% in the next_state callback of a statem or fsm property. This lowers its
+%%% usability for stateless properties, forcing a kind of fold approach where
+%%% commands are generated sequentially, flattened with a `?LET' to allow the
+%%% model's reuse during next call, and so on recursively.
+%%%
+%%% It might be sufficient to choose Approach 3, and then provide a utilitary
+%%% function `populate_dir(Dir) -> {Model, SymbolicCalls}' that provides
+%%% both a model and an `eval()'-friendly list of calls to actualize it in
+%%% stateless properties.
+%%% @end
+-module(dirmodel).
+-include_lib("proper/include/proper.hrl").
+         %% meta calls for property writers
+-export([new/0, apply_call/3,
+         %% mutation calls for propery writers
+         file_add/2, file_change/2, file_delete/2,
+         %% stateless helper
+         populate_dir/1]).
+%% private exports for testing and extending the model itself
+-export([at/2, insert_at/3, delete_at/2, file/2, dir/1]).
+
+-record(dir, {path :: string(),
+              nodes = [] :: [dir() | file()]}).
+-record(file, {path :: string(),
+               content :: binary(),
+               hash :: binary()}).
+-type dir() :: #dir{}. % internal representation of a directory
+-type file() :: #file{}. % internal representation of a file
+-type tnode() :: dir() | file().
+-type tree() :: dir(). % a tree's root
+-type path() :: [name(), ...]. % a path to a file in the model
+-type name() :: string(). % the fragment of a path (filename)
+
+%% @doc Create an empty model tree.
+-spec new() -> tree().
+new() ->
+    dir(".").
+
+-spec populate_dir(file:filename()) ->
+    proper_gen:generator(). % {tree(), [{call, _, _, _}]}
+populate_dir(Dir) ->
+    ?SIZED(Size, populate_dir(Dir, new(), [], Size)).
+
+populate_dir(_Dir, T, Ops, Size) when Size =< 0 ->
+    {T, Ops};
+populate_dir(Dir, T, Ops, Size) ->
+    ?LET(EvalT, T,
+         ?LET(Op, file_add(Dir, EvalT),
+              populate_dir(Dir, apply_call(Dir, EvalT, Op), [Op|Ops], Size-1))).
+
+-spec file_add(file:filename(), tree()) ->
+    proper_gen:generator(). % {call, _, _, _}
+file_add(Dir, T) ->
+    PathNameGen = ?SUCHTHAT({P,N}, {path(), dirgen:path_chars()},
+                            at(T, P++[N]) =:= undefined),
+    ?LET({{Path, Name}, Content}, {PathNameGen, binary()},
+          {call, file, write_file, [filename:join([Dir, filename:join(Path), Name]),
+                                     Content, [sync]]}).
+
+-spec file_change(file:filename(), tree()) ->
+    proper_gen:generator(). % {call, _, _, _}
+file_change(Dir, T) ->
+    ?LET(Path, oneof(file_paths(T)),
+      begin
+        {ok, #file{content = C}} = at(T, Path),
+        ContentGen = ?SUCHTHAT(B, binary(), B =/= C),
+        ?LET(Content, ContentGen,
+             {call, file, write_file, [filename:join([Dir, filename:join(Path)]),
+                                         Content, [sync]]})
+      end).
+
+-spec file_delete(file:filename(), tree()) ->
+    proper_gen:generator(). % {call, _, _, _}
+file_delete(Dir, T) ->
+    ?LET(Path, oneof(file_paths(T)),
+         {call, file, delete, [filename:join([Dir, filename:join(Path)])]}).
+
+-spec apply_call(file:filename(), tree(), {call, file, atom(), list()}) ->
+    tree().
+apply_call(Dir, T, {call, file, delete, [Path]}) ->
+    Parts = suffix(filename:split(Dir), filename:split(Path)),
+    delete_at(T, Parts);
+apply_call(Dir, T, {call, file, write_file, [Path, Contents | _]}) ->
+    Parts = suffix(filename:split(Dir), filename:split(Path)),
+    Root = lists:droplast(Parts),
+    Name = lists:last(Parts),
+    case at(T, Parts) of
+        undefined -> % new file
+            insert_at(T, Root, file(Name, Contents));
+        _ ->
+            insert_at(delete_at(T, Parts), Root, file(Name, Contents))
+    end.
+
+
+%% @doc Create a new file node. To be inserted within the model tree
+%% with the help of `insert_at/3'.
+-spec file(name(), binary()) -> file().
+file(Name, Content) when is_list(Name), is_binary(Content) ->
+    #file{path=Name,
+          content=Content,
+          hash = crypto:hash(sha256, Content)}.
+
+%% @doc Create a new directory node. To be inserted within the model
+%% tree with the help of `insert_at/3'.
+-spec dir(name()) -> dir().
+dir(Path) ->
+    #dir{path=Path}.
+
+%% @doc Extract the node of the model tree according to its path.
+%% Useful for mutations or comparing tree internals.
+-spec at(tree(), path()) -> {ok, [tnode()] | file()} | undefined.
+at(File = #file{path=Name}, [Name]) ->
+    {ok, File};
+at(Dir = #dir{path=Name}, [Name]) ->
+    {ok, Dir};
+at(#dir{path=Name, nodes=Nodes}, [Name, Next | Rest]) ->
+    case find_node_by_name(Nodes, Next) of
+        undefined -> undefined;
+        Node -> at(Node, [Next|Rest])
+    end;
+at(_, _) ->
+    undefined.
+
+%% @doc allows the insertion of a new node within a model tree
+%% based on its path. If you are looking to replace the node,
+%% you should use `delete_at/2' first to remove it. This exclusive
+%% addition of tree nodes aims to prevent silently transforming a
+%% dir into a file or a file into a dir.
+%% If a path is given such as `[A,B,C]' and `B' does not exist in
+%% the model, it gets implicitly created as a directory node.
+-spec insert_at(tree(), path(), tnode()) -> tree().
+insert_at(D=#dir{path=Name, nodes=Nodes}, [Name], Node) ->
+    NextName = find_name(Node),
+    undefined = find_node_by_name(Nodes, NextName),
+    D#dir{nodes=[Node|Nodes]};
+insert_at(D=#dir{path=Name, nodes=Nodes}, [Name, Next | Rest], NewNode) ->
+    case find_node_by_name(Nodes, Next) of
+        undefined ->
+            D#dir{nodes=[insert_at(dir(Next), [Next | Rest], NewNode) | Nodes]};
+        Node ->
+            D#dir{nodes=[insert_at(Node, [Next | Rest], NewNode) | Nodes -- [Node]]}
+    end.
+
+%% @doc allows the removal of a node within a model tree
+%% based on its path.
+%% If a path is not existing in the tree, the call errors out
+%% since the intent is to quickly highlight faults in model usage.
+%% It is also illegal to remove the root from the tree, since
+%% this would result in an undefined model.
+-spec delete_at(tree(), path()) -> tree().
+delete_at(D=#dir{path=Name, nodes=Nodes}, [Name, Next | Rest]) ->
+    case find_node_by_name(Nodes, Next) of
+        undefined ->
+            error(bad_delete);
+        Node when Rest =:= [] ->
+            D#dir{nodes=Nodes -- [Node]};
+        Node when Rest =/= [] ->
+            D#dir{nodes=[delete_at(Node, [Next|Rest]) | Nodes -- [Node]]}
+    end.
+
+%% @private
+%% used during directory traversal to find the right entry
+%% in a directory.
+-spec find_node_by_name([dir()|file()], name()) -> undefined | dir() | file().
+find_node_by_name([], _) -> undefined;
+find_node_by_name([F=#file{path=Name} | _], Name) -> F;
+find_node_by_name([D=#dir{path=Name} | _], Name) -> D;
+find_node_by_name([_ | Rest], Name) -> find_node_by_name(Rest, Name).
+
+%% @private
+%% utility function to get the name of any node type
+find_name(F = #file{}) -> F#file.path;
+find_name(D = #dir{}) -> D#dir.path.
+
+%% @private
+%% Return all paths leading to files
+file_paths(Tree) ->
+    file_paths(Tree, [], [], []).
+
+file_paths(#file{path=P}, Current, [], Acc) ->
+    [lists:reverse(Current, [P]) | Acc];
+file_paths(#file{path=P}, Current, [{Next,Node}|ToDo], Acc) ->
+    file_paths(Node, Next, ToDo, [lists:reverse(Current, [P]) | Acc]);
+file_paths(#dir{nodes=[]}, _, [], Acc) ->
+    Acc;
+file_paths(#dir{nodes=Ns, path=P}, Current, ToDo, Acc) ->
+    Queue = [{[P|Current], N} || N <- Ns],
+    case ToDo of
+        [{Next,Node}|ToDoNext] ->
+            file_paths(Node, Next, ToDoNext ++ Queue, Acc);
+        [] ->
+            case Queue of
+                [] ->
+                    Acc;
+                [{Next,Node}|ToDoNext] ->
+                    file_paths(Node, Next, ToDoNext, Acc)
+            end
+    end.
+
+%% @private
+%% Drop the common prefix of both lists;
+%% we assume that `A' is longer or as long as `B'.
+suffix([], Bs) -> ["."|Bs];
+suffix([A|As], [A|Bs]) -> suffix(As, Bs);
+suffix(_, Bs) -> ["."|Bs].
+
+%% @private
+%% Generator for dirmodel full paths
+path() ->
+    ?LET(P, dirgen:path(), ["." | P]). % always a ./ in dirmodel

--- a/apps/revault/test/prop_dirmodel.erl
+++ b/apps/revault/test/prop_dirmodel.erl
@@ -1,0 +1,62 @@
+%%% @doc
+%%% Test suite for the `dirmodel' generator library with various calls
+%%% as required.
+%%% @end
+-module(prop_dirmodel).
+-include_lib("proper/include/proper.hrl").
+-compile(export_all).
+-define(DIR, "/tmp/fake/"). % should not write there for real
+
+prop_added_file_found(doc) ->
+    "Any file added to the model can be found back in it";
+prop_added_file_found(opts) ->
+    [{numtests, 10}].
+prop_added_file_found() ->
+    ?FORALL({Model, Op},
+            ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
+                 {M, dirmodel:file_add(?DIR, M)}),
+      begin
+        {call, file, write_file, [Path|_]} = Op,
+        NewModel = dirmodel:apply_call(?DIR, Model, Op),
+        Parts = normalize(?DIR, Path),
+        dirmodel:at(Model, Parts) =:= undefined
+        andalso
+        is_tuple(dirmodel:at(NewModel, Parts))
+      end).
+
+prop_deleted_file_gone(doc) ->
+    "Any file deleted from the model won't be found again";
+prop_deleted_file_gone(opts) ->
+    [{numtests, 10}].
+prop_deleted_file_gone() ->
+    ?FORALL({Model, Op},
+            ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
+                 {M, dirmodel:file_delete(?DIR, M)}),
+      begin
+        {call, file, delete, [Path|_]} = Op,
+        NewModel = dirmodel:apply_call(?DIR, Model, Op),
+        Parts = normalize(?DIR, Path),
+        is_tuple(dirmodel:at(Model, Parts))
+        andalso
+        dirmodel:at(NewModel, Parts) =:= undefined
+      end).
+
+prop_changed_file(doc) ->
+    "Any file changed from the model is detected as such";
+prop_changed_file(opts) ->
+    [{numtests, 10}].
+prop_changed_file() ->
+    ?FORALL({Model, Op},
+            ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
+                 {M, dirmodel:file_change(?DIR, M)}),
+      begin
+        {call, file, write_file, [Path|_]} = Op,
+        NewModel = dirmodel:apply_call(?DIR, Model, Op),
+        Parts = normalize(?DIR, Path),
+        {ok, F1} = dirmodel:at(Model, Parts),
+        {ok, F2} = dirmodel:at(NewModel, Parts),
+        F1 =/= F2
+      end).
+
+normalize(Base, Path) ->
+    ["." | filename:split(string:prefix(Path, Base))].

--- a/apps/revault/test/prop_dirmodel.erl
+++ b/apps/revault/test/prop_dirmodel.erl
@@ -16,7 +16,7 @@ prop_added_file_found() ->
             ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
                  {M, dirmodel:file_add(?DIR, M)}),
       begin
-        {call, file, write_file, [Path|_]} = Op,
+        {call, _, write_file, [Path|_]} = Op,
         NewModel = dirmodel:apply_call(?DIR, Model, Op),
         Parts = normalize(?DIR, Path),
         dirmodel:at(Model, Parts) =:= undefined
@@ -33,7 +33,7 @@ prop_deleted_file_gone() ->
             ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
                  {M, dirmodel:file_delete(?DIR, M)}),
       begin
-        {call, file, delete, [Path|_]} = Op,
+        {call, _, delete_file, [Path|_]} = Op,
         NewModel = dirmodel:apply_call(?DIR, Model, Op),
         Parts = normalize(?DIR, Path),
         is_tuple(dirmodel:at(Model, Parts))
@@ -50,7 +50,7 @@ prop_changed_file() ->
             ?LET({M,_Ops}, dirmodel:populate_dir(?DIR),
                  {M, dirmodel:file_change(?DIR, M)}),
       begin
-        {call, file, write_file, [Path|_]} = Op,
+        {call, _, change_file, [Path|_]} = Op,
         NewModel = dirmodel:apply_call(?DIR, Model, Op),
         Parts = normalize(?DIR, Path),
         {ok, F1} = dirmodel:at(Model, Parts),

--- a/apps/revault/test/prop_dirmon_poll_statem.erl
+++ b/apps/revault/test/prop_dirmon_poll_statem.erl
@@ -31,47 +31,47 @@ prop_test() ->
 %%%%%%%%%%%%%
 %% @doc Initial model value at system start. Should be deterministic.
 initial_state() ->
-    #{set => [],
-      ops => [],
-      dirs => []}.
+    #{ops => [],
+      set => [],
+      snapshot => dirmodel:new(),
+      model => dirmodel:new()}.
 
 %% @doc List of possible commands to run against the system
-command(State) ->
+command(#{model := T, set := Set}) ->
     Calls = [
-        {call, ?MODULE, add_file, [new_filename(State), contents()]},
-        {call, revault_dirmon_poll, rescan, [?DIR, maps:get(set, State)]}
+        ?LAZY(dirmodel:file_add(?DIR, T)),
+        {call, revault_dirmon_poll, rescan, [?DIR, Set]}
     ]
-    ++ case maps:size(State) of
-        3 -> % the two static atom keys
+    ++ case dirmodel:has_files(T) of
+        false ->
             [];
-        _ ->
-            [{call, ?MODULE, change_file, [filename(State), contents()]},
-             {call, ?MODULE, delete_file, [filename(State)]}]
+        true ->
+            [?LAZY(dirmodel:file_change(?DIR, T)),
+             ?LAZY(dirmodel:file_delete(?DIR, T))]
     end,
     oneof(Calls).
 
 %% @doc Determines whether a command should be valid under the
 %% current state.
-precondition(State, {call, _, add_file, [Filename, _Contents]}) ->
-    not maps:is_key(Filename, State) andalso not_is_dir(Filename, State);
-precondition(State, {call, _, change_file, [Filename, Contents]}) ->
-    case maps:find(Filename, State) of
-        error ->
-            false;
-        {ok, {_Hash, Contents}} ->
-            false;
-        {ok, {_Hash, _OldContents}} ->
-            true
+precondition(#{model := T}, {call, _, write_file, [Filename, _Contents | _]}) ->
+    dirmodel:type(?DIR, T, Filename) =:= undefined;
+precondition(#{model := T}, {call, _, change_file, [Filename, Contents | _]}) ->
+    Type = dirmodel:type(?DIR, T, Filename),
+    is_tuple(Type) andalso
+    element(1, Type) =:= file andalso
+    element(3, Type) =/= Contents;
+precondition(#{model := T}, {call, _, delete_file, [Filename | _]}) ->
+    case dirmodel:type(?DIR, T, Filename) of
+        {file, _, _} -> true;
+        _ -> false
     end;
-precondition(State, {call, _, delete_file, [Filename]}) ->
-    maps:is_key(Filename, State);
 precondition(_State, {call, _Mod, _Fun, _Args}) ->
     true.
 
 %% @doc Given the state `State' *prior* to the call
 %% `{call, Mod, Fun, Args}', determine whether the result
 %% `Res' (coming from the actual system) makes sense.
-postcondition(_State, {call, _, add_file, _}, ok) ->
+postcondition(_State, {call, _, write_file, _}, ok) ->
     true;
 postcondition(_State, {call, _, change_file, _}, ok) ->
     true;
@@ -79,116 +79,67 @@ postcondition(_State, {call, _, delete_file, _}, ok) ->
     true;
 postcondition(State, {call, _, rescan, [_, _]}, Ret) ->
     {ExpDel, ExpAdd, ExpMod} = merge_ops(
-        [{Op, {filename:join(F),H}} || {Op, {F,H}} <- maps:get(ops, State)],
-        maps:get(set, State)
+        [{Op, {F,C}} || {Op, {F,C}} <- maps:get(ops, State)],
+        maps:get(snapshot, State)
     ),
-    ExpSet = lists:sort(
-        [{filename:join(File), Hash}
-         || {File, {Hash, _}} <- maps:to_list(State), not is_atom(File)]
-    ),
-    Res = {{ExpDel, ExpAdd, ExpMod}, ExpSet} =:= Ret,
+    ExpSet = dirmodel:hashes(?DIR, maps:get(model, State)),
+    Res = {hash({ExpDel, ExpAdd, ExpMod}), ExpSet} =:= Ret,
     Res orelse io:format("===~n~p~n---~n~p~n===~n",
-                         [{{ExpDel, ExpAdd, ExpMod}, ExpSet}, Ret]),
+                         [{hash({ExpDel, ExpAdd, ExpMod}), ExpSet}, Ret]),
     Res;
 postcondition(_State, {call, _Mod, _Fun, _Args}, _Res) ->
     false.
 
 %% @doc Assuming the postcondition for a call was true, update the model
 %% accordingly for the test to proceed.
-next_state(State, _Res, {call, _, add_file, [FileName, Contents]}) ->
-    Hash = crypto:hash(sha256, Contents),
-    Dirs = maps:get(dirs, State),
-    Path = lists:droplast(FileName),
-    State#{FileName => {Hash, Contents},
-           dirs => lists:usort([Path|Dirs])--[[]],
-           ops => [{add, {FileName, Hash}} | maps:get(ops, State)]};
-next_state(State, _Res, {call, _, change_file, [FileName, Contents]}) ->
-    Hash = crypto:hash(sha256, Contents),
-    State#{FileName => {Hash, Contents},
-           ops => [{change, {FileName, Hash}} | maps:get(ops, State)]};
-next_state(State, _Res, {call, _, delete_file, [FileName]}) ->
-    {Hash, _} = maps:get(FileName, State),
-    NewState = maps:remove(FileName, State),
-    NewState#{ops => [{delete, {FileName, Hash}} | maps:get(ops, State)]};
+next_state(State, _Res, Op = {call, _, write_file, [FileName, Contents | _]}) ->
+    State#{ops => [{add, {FileName, Contents}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
+next_state(State, _Res, Op = {call, _, change_file, [FileName, Contents | _]}) ->
+    State#{ops => [{change, {FileName, Contents}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
+next_state(State, _Res, Op = {call, _, delete_file, [FileName | _]}) ->
+    {file, _, Val} = dirmodel:type(?DIR, maps:get(model, State), FileName),
+    State#{ops => [{delete, {FileName, Val}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
 next_state(State, Res, {call, _, rescan, [_, _]}) ->
     %% Symbolic call to work around the symbolic execution issues
     %% without having to wrap the rescan calls furthermore.
     State#{set := {call, erlang, element, [2, Res]},
-           ops => []};
+           ops := [],
+           snapshot := maps:get(model, State)};
 next_state(State, _Res, {call, _Mod, _Fun, _Args}) ->
     NewState = State,
     NewState.
 
-%%%%%%%%%%%%%%%%%%
-%%% GENERATORS %%%
-%%%%%%%%%%%%%%%%%%
-new_filename(Map) ->
-    ?SUCHTHAT(
-       Path,
-       ?LET(Base, revault_test_utils:gen_path(),
-            filename:split(filename:join(?DIR, Base))),
-       not_is_dir(Path, Map)
-    ).
-
-not_is_dir(Path, Map) ->
-    lists:all(
-        fun(ExistingDir) -> not lists:prefix(Path, ExistingDir) end,
-        maps:get(dirs, Map)
-    )
-    andalso
-    lists:all(
-        fun(Existing) -> not lists:prefix(Existing, Path) end,
-        [K || K <- maps:keys(Map), not is_atom(K)]
-    ).
-
-filename(Map) ->
-    oneof([P || P <- maps:keys(Map), not is_atom(P)]).
-
-contents() ->
-    binary().
-
-%%%%%%%%%%%%%%%%%%%
-%%% MODEL CALLS %%%
-%%%%%%%%%%%%%%%%%%%
-add_file(FileName, Contents) ->
-    Path = filename:join(FileName),
-    filelib:ensure_dir(Path),
-    file:write_file(Path, Contents, [sync, raw]).
-
-change_file(FileName, Contents) ->
-    file:write_file(filename:join(FileName), Contents, [sync, raw]).
-
-delete_file(FileName) ->
-    file:delete(filename:join(FileName)).
-
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%
 %%%%%%%%%%%%%%%
-merge_ops(Ops, InitSet) ->
-    Map = maps:from_list([{File, {Op, Hash}}
-                          || {Op, {File, Hash}} <- lists:reverse(Ops)]),
-    process_ops(Map, InitSet).
+merge_ops(Ops, Snapshot) ->
+    Map = maps:from_list([{File, {Op, Content}}
+                          || {Op, {File, Content}} <- lists:reverse(Ops)]),
+    process_ops(Map, Snapshot).
 
-process_ops(Map, InitSet) ->
+process_ops(Map, Snapshot) ->
     {Del, Add, Mod} = maps:fold(
         fun(File, Ops, {Del, Add, Mod}) ->
-            Init = proplists:get_value(File, InitSet),
+            Init = dirmodel:type(?DIR, Snapshot, File),
             case {Ops, Init} of
                 %% unchanged over both polls
-                {{delete, _Hash}, undefined} ->
+                {{delete, _Content}, undefined} ->
                     {Del, Add, Mod};
                 %% deleted file
-                {{delete, _Hash}, OldHash} ->
-                    {[{File, OldHash}|Del], Add, Mod};
+                {{delete, _Content}, {file, _, OldContent}} ->
+                    {[{File, OldContent}|Del], Add, Mod};
                 %% sequence ended in added file
-                {{_, Hash}, undefined} ->
-                    {Del, [{File, Hash}|Add], Mod};
+                {{_, Content}, undefined} ->
+                    {Del, [{File, Content}|Add], Mod};
                 %% changes had no impact
-                {{_, Hash}, Hash} ->
+                {{_, Content}, {file, _, Content}} ->
                     {Del, Add, Mod};
                 %% sequence ended in changed file
-                {{_, Hash}, _} ->
-                    {Del, Add, [{File, Hash}|Mod]}
+                {{_, Content}, _} ->
+                    {Del, Add, [{File, Content}|Mod]}
             end
         end,
         {[], [], []},
@@ -196,3 +147,6 @@ process_ops(Map, InitSet) ->
     ),
     {lists:sort(Del), lists:sort(Add), lists:sort(Mod)}.
 
+hash({Del, Add, Mod}) ->
+    F = fun({F, Content}) -> {F, crypto:hash(sha256, Content)} end,
+    {lists:map(F, Del), lists:map(F, Add), lists:map(F, Mod)}.


### PR DESCRIPTION
See the module doc for dirmodel.erl

TL:DR; introduce predictability in statem tests by carrying a memory representation of the filesystem and its related operations to better direct and model actual operations on disk. This ends up, among other things, better tracking directories and giving counterexample reproducibility, and might be a bit faster.