### PR TITLE
Add memory tracking capabilities based on events

### DIFF
--- a/apps/revault/src/revault_dirmon_event.erl
+++ b/apps/revault/src/revault_dirmon_event.erl
@@ -1,3 +1,9 @@
+%%% @doc
+%%% Module in charge of running a server that monitors a given directory
+%%% and forwards events related to all detected changes.
+%%% The events are sent over the `gproc' property `{p, l, Name}', where
+%%% `Name' is the name given to the server.
+%%% @end
 -module(revault_dirmon_event).
 -export([start_link/2, force_scan/2, stop/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).

--- a/apps/revault/src/revault_dirmon_poll.erl
+++ b/apps/revault/src/revault_dirmon_poll.erl
@@ -1,9 +1,13 @@
+%%% @doc
+%%% Basic polling mechanism used to scan directories and find
+%%% all the file hashes and fetch the changes they might contain
+%%% @end
 -module(revault_dirmon_poll).
 -export([scan/1, rescan/2]).
 
 -type hash() :: binary().
 -type set() :: [{file:filename(), hash()}].
--export_type([set/0]).
+-export_type([set/0, hash/0]).
 
 -ifdef(TEST).
 -export([diff_set/2]).

--- a/apps/revault/src/revault_dirmon_tracker.erl
+++ b/apps/revault/src/revault_dirmon_tracker.erl
@@ -1,0 +1,62 @@
+%%% @doc
+%%% Server in charge of listening to events about a given directory and
+%%% tracking all the changes in memory
+%%% @end
+-module(revault_dirmon_tracker).
+-behviour(gen_server).
+-define(VIA_GPROC(Name), {via, gproc, {n, l, {?MODULE, Name}}}).
+-export([start_link/1, stop/1, file/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-opaque stamp() :: {at, integer()}.
+-export_type([stamp/0]).
+
+%% optimization hint: replace the queue by an ordered_set ETS table?
+-record(state, {
+    snapshot = #{} :: #{file:filename() =>
+                        {stamp(), revault_dirmon_poll:hash()}}
+}).
+
+start_link(Name) ->
+    gen_server:start_link(?VIA_GPROC(Name), ?MODULE, [Name], []).
+
+file(Name, File) ->
+    gen_server:call(?VIA_GPROC(Name), {file, File}).
+
+stop(Name) ->
+    gen_server:stop(?VIA_GPROC(Name), normal, 5000).
+init([Name]) ->
+    true = gproc:reg({p, l, Name}),
+    {ok, #state{}}.
+
+
+handle_call({file, Name}, _From, State = #state{snapshot=Map}) ->
+    case Map of
+        #{Name := Status} ->
+            {reply, Status, State};
+        _ ->
+            {reply, undefined, State}
+    end;
+handle_call(_Call, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({dirmon, _Name, {Transform, _} = Op}, State=#state{snapshot=Map})
+        when Transform == deleted;
+             Transform == added;
+             Transform == changed ->
+    {noreply, State#state{snapshot = apply_operation(Op, Map)}};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+stamp() ->
+    {at, erlang:unique_integer([positive, monotonic])}.
+
+apply_operation({added, {FileName, Hash}}, SetMap) ->
+    SetMap#{FileName => {stamp(), Hash}};
+apply_operation({deleted, {FileName, _Hash}}, SetMap) ->
+    SetMap#{FileName := {stamp(), deleted}};
+apply_operation({changed, {FileName, Hash}}, SetMap) ->
+    SetMap#{FileName := {stamp(), Hash}}.

--- a/apps/revault/test/prop_dirmon_tracker.erl
+++ b/apps/revault/test/prop_dirmon_tracker.erl
@@ -1,0 +1,173 @@
+-module(prop_dirmon_tracker).
+-include_lib("proper/include/proper.hrl").
+-define(DIR, "_build/test/scratch").
+-define(LISTENER_NAME, {?MODULE, ?DIR}).
+-compile(export_all).
+
+%% Model Callbacks
+-export([command/1, initial_state/0, next_state/3,
+         precondition/2, postcondition/3]).
+
+%%%%%%%%%%%%%%%%%%
+%%% PROPERTIES %%%
+%%%%%%%%%%%%%%%%%%
+prop_test(doc) ->
+   "files are added, changed, and removed, and the model checks that between "
+   "any two scans, the data discovered on disk matches what the operation "
+   "logically does when the disk is abstracted, and is forwarded as events, "
+   "which are then used to carry a stateful versioned snapshot of hashes in memory".
+prop_test() ->
+    ?SETUP(fun() ->
+        {ok, Apps} = application:ensure_all_started(gproc),
+        fun() ->
+             [application:stop(App) || App <- Apps],
+             revault_test_utils:teardown_scratch_dir(?DIR) % safety
+        end
+    end,
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                revault_test_utils:setup_scratch_dir(?DIR),
+                {ok, _} = revault_dirmon_event:start_link(
+                    ?LISTENER_NAME,
+                    #{directory => ?DIR,
+                      poll_interval => 6000000} % too long to interfere
+                ),
+                {ok, _Listener} = revault_dirmon_tracker:start_link(?LISTENER_NAME),
+                {History, State, Result} = run_commands(?MODULE, Cmds),
+                revault_dirmon_tracker:stop(?LISTENER_NAME),
+                revault_dirmon_event:stop(?LISTENER_NAME),
+                revault_test_utils:teardown_scratch_dir(?DIR),
+                ?WHENFAIL(io:format("History: ~p\nState: ~p\nResult: ~p\n",
+                                    [History,State,Result]),
+                          aggregate(command_names(Cmds), Result =:= ok))
+            end)).
+
+%%%%%%%%%%%%%
+%%% MODEL %%%
+%%%%%%%%%%%%%
+%% @doc Initial model value at system start. Should be deterministic.
+initial_state() ->
+    #{ops => [],
+      snapshot => dirmodel:new(),
+      model => dirmodel:new()}.
+
+%% @doc List of possible commands to run against the system
+command(#{model := T, ops := Ops}) ->
+    Calls = [
+        ?LAZY(dirmodel:file_add(?DIR, T)),
+        {call, ?MODULE, check_files, [?DIR, T, Ops]}
+    ]
+    ++ case dirmodel:has_files(T) of
+        false ->
+            [];
+        true ->
+            [?LAZY(dirmodel:file_change(?DIR, T)),
+             ?LAZY(dirmodel:file_delete(?DIR, T))]
+    end,
+    oneof(Calls).
+
+%% @doc Determines whether a command should be valid under the
+%% current state.
+precondition(#{model := T}, {call, _, write_file, [Filename, _Contents | _]}) ->
+    dirmodel:type(?DIR, T, Filename) =:= undefined;
+precondition(#{model := T}, {call, _, change_file, [Filename, Contents | _]}) ->
+    Type = dirmodel:type(?DIR, T, Filename),
+    is_tuple(Type) andalso
+    element(1, Type) =:= file andalso
+    element(3, Type) =/= Contents;
+precondition(#{model := T}, {call, _, delete_file, [Filename | _]}) ->
+    case dirmodel:type(?DIR, T, Filename) of
+        {file, _, _} -> true;
+        _ -> false
+    end;
+precondition(#{model := T1}, {call, _, check_files, [_, T2, _]}) ->
+    dirmodel:hashes(?DIR, T1) =:= dirmodel:hashes(?DIR, T2);
+precondition(_State, {call, _Mod, _Fun, _Args}) ->
+    true.
+
+%% @doc Given the state `State' *prior* to the call
+%% `{call, Mod, Fun, Args}', determine whether the result
+%% `Res' (coming from the actual system) makes sense.
+postcondition(_State, {call, _, write_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, change_file, _}, ok) ->
+    true;
+postcondition(_State, {call, _, delete_file, _}, ok) ->
+    true;
+postcondition(State, {call, _, check_files, _}, {Exist, Deleted, Unknown}) ->
+    Model = maps:get(model, State),
+    ModelExist = dirmodel:hashes(?DIR, Model),
+    Res = lists:sort(ModelExist) =:= lists:sort(Exist)
+          andalso lists:all(fun({_Vsn, deleted}) -> true; (_) -> false end, Deleted)
+          andalso lists:all(fun(Entry) -> Entry == undefined end, Unknown),
+    Res orelse io:format("BAD CHECK: ~p~n~p", [{Exist, Deleted, Unknown}, ModelExist]),
+    Res;
+postcondition(_State, {call, _Mod, _Fun, _Args}, _Res) ->
+    false.
+
+%% @doc Assuming the postcondition for a call was true, update the model
+%% accordingly for the test to proceed.
+next_state(State, _Res, Op = {call, _, write_file, [FileName, Contents | _]}) ->
+    State#{ops => [{add, {FileName, Contents}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
+next_state(State, _Res, Op = {call, _, change_file, [FileName, Contents | _]}) ->
+    State#{ops => [{change, {FileName, Contents}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
+next_state(State, _Res, Op = {call, _, delete_file, [FileName | _]}) ->
+    {file, _, Val} = dirmodel:type(?DIR, maps:get(model, State), FileName),
+    State#{ops => [{delete, {FileName, Val}} | maps:get(ops, State)],
+           model => dirmodel:apply_call(?DIR, maps:get(model, State), Op)};
+next_state(State, _Res, {call, _, check_files, _}) ->
+    State#{ops := [],
+           snapshot := maps:get(model, State)};
+next_state(State, _Res, _Op = {call, _Mod, _Fun, _Args}) ->
+    NewState = State,
+    NewState.
+
+%%%%%%%%%%%%%%%%%%%
+%%% MODEL CALLS %%%
+%%%%%%%%%%%%%%%%%%%
+%% @doc The role of the tracker is to provide a stable abstraction of
+%% the current state on disk, by using some versioning mechanism that
+%% allows comparison of valid or outdated states (eventually: conflicting ones).
+%% At a later point, we'll then be able to forward state updates to other
+%% nodes as events and ask these to apply the changes, which they'll be
+%% able to handle properly.
+%%
+%% So the role should be: give me the last state and known version of the file:
+%% - {Vsn, deleted}
+%% - {Vsn, Hash}
+%% - undefined
+%%
+%% This shim wrapper therefore makes a call to scan all known files (plus unknown
+%% ones) to make sure they're truly gone.
+check_files(Dir, Model, Ops) ->
+    ok = revault_dirmon_event:force_scan(?LISTENER_NAME, 5000), % sync call
+    KnownFiles = [File || {File, _Hash} <- dirmodel:hashes(Dir, Model)],
+    KnownHashes = [{File,
+                    drop_vsn(revault_dirmon_tracker:file(?LISTENER_NAME, File))}
+                   || File <- KnownFiles],
+    DeletedFiles = [File || {delete, {File, _Hash}} <- Ops,
+                            file_deleted(File, Dir, Model, Ops)],
+    DeletedData = [{File,
+                    drop_vsn(revault_dirmon_tracker:file(?LISTENER_NAME, File))}
+                   || File <- DeletedFiles],
+    {KnownHashes, DeletedData,
+     [revault_dirmon_tracker:file(?LISTENER_NAME,
+                                  "this file has got to be bad")]}.
+
+drop_vsn({_Vsn, Hash}) -> Hash;
+drop_vsn(NoVsn) -> NoVsn.
+
+%% @private check that the file is deleted, but also that it was deleted
+%% only *after* a prior check. Otherwise, we're checking between two scans
+%% and it's possible that the file was added and then deleted without
+%% ever being noticed by the system. In such a case, no events will have
+%% been sent to the tracker, and it is impossible for it to know about it.
+file_deleted(File, Dir, Model, Ops) ->
+    Type = dirmodel:type(Dir, Model, File),
+    (Type =:= dir orelse Type =:= undefined)
+    andalso 
+    [] == [Op || Op = {add, {Name, _}} <- Ops,
+                         Name =:= File].


### PR DESCRIPTION
- The version is just a monotonic integer and is currently not used
- The events are followed as-is
- The interface chosen is per-file in order to track state, and returns
  versions
- tests are included

Extending to alternative polling methods should be
easy enough and would only require minimal test changes as long as other
pollers publish similar events.

Extending to disk storage would require a kind of "epoch" allocation on
the current integers, which would represent 'generations' of content.
Extending storage to be comparable across distributed nodes will require
changing the version mechanism altogether to something like vector
clocks, version vectors, or interval tree clocks, but can be tackled
later on as long as a comparison function that handles the opaque type
is added.

related to #6 