### PR TITLE
Track monitored directory state on disk

### DIFF
--- a/apps/revault/src/revault_dirmon_tracker.erl
+++ b/apps/revault/src/revault_dirmon_tracker.erl
@@ -5,7 +5,7 @@
 -module(revault_dirmon_tracker).
 -behviour(gen_server).
 -define(VIA_GPROC(Name), {via, gproc, {n, l, {?MODULE, Name}}}).
--export([start_link/1, stop/1, file/2]).
+-export([start_link/2, stop/1, file/2, files/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -opaque stamp() :: {at, integer()}.
@@ -14,21 +14,29 @@
 %% optimization hint: replace the queue by an ordered_set ETS table?
 -record(state, {
     snapshot = #{} :: #{file:filename() =>
-                        {stamp(), revault_dirmon_poll:hash()}}
+                        {stamp(), revault_dirmon_poll:hash()}},
+    storage = undefined :: file:filename() | undefined
 }).
 
-start_link(Name) ->
-    gen_server:start_link(?VIA_GPROC(Name), ?MODULE, [Name], []).
+start_link(Name, File) ->
+    gen_server:start_link(?VIA_GPROC(Name), ?MODULE, [Name, File], []).
 
 file(Name, File) ->
     gen_server:call(?VIA_GPROC(Name), {file, File}).
 
+files(Name) ->
+    gen_server:call(?VIA_GPROC(Name), files).
+
 stop(Name) ->
     gen_server:stop(?VIA_GPROC(Name), normal, 5000).
-init([Name]) ->
-    true = gproc:reg({p, l, Name}),
-    {ok, #state{}}.
 
+init([Name, File]) ->
+    Snapshot = restore_snapshot(File),
+    true = gproc:reg({p, l, Name}),
+    {ok, #state{
+        snapshot = Snapshot,
+        storage = File
+    }}.
 
 handle_call({file, Name}, _From, State = #state{snapshot=Map}) ->
     case Map of
@@ -37,6 +45,8 @@ handle_call({file, Name}, _From, State = #state{snapshot=Map}) ->
         _ ->
             {reply, undefined, State}
     end;
+handle_call(files, _From, State = #state{snapshot=Map}) ->
+    {reply, Map, State};
 handle_call(_Call, _From, State) ->
     {noreply, State}.
 
@@ -47,7 +57,9 @@ handle_info({dirmon, _Name, {Transform, _} = Op}, State=#state{snapshot=Map})
         when Transform == deleted;
              Transform == added;
              Transform == changed ->
-    {noreply, State#state{snapshot = apply_operation(Op, Map)}};
+    NewState = State#state{snapshot = apply_operation(Op, Map)},
+    save_snapshot(NewState),
+    {noreply, NewState};
 handle_info(_Msg, State) ->
     {noreply, State}.
 
@@ -60,3 +72,32 @@ apply_operation({deleted, {FileName, _Hash}}, SetMap) ->
     SetMap#{FileName := {stamp(), deleted}};
 apply_operation({changed, {FileName, Hash}}, SetMap) ->
     SetMap#{FileName := {stamp(), Hash}}.
+
+restore_snapshot(File) ->
+    case file:consult(File) of
+        {error, enoent} ->
+            #{};
+        {ok, [Snapshot]} ->
+            Snapshot
+    end.
+
+save_snapshot(#state{storage = undefined}) ->
+    %% diskless mode
+    ok;
+save_snapshot(#state{snapshot = Snap, storage = File}) ->
+    %% 1. write the file to a temporary file
+    %% 2. confirm it is good
+    %% 3. rename the file to the canonical name
+    %%
+    %% rename is atomic in POSIX file systems so we prevent corrupting
+    %% the snapshot on a failure on a halfway write, but both files
+    %% should be in the same directory so that we don't accidentally
+    %% end up on two distinct filesystems, which then blocks renaming
+    %% from working.
+    RandVal = float_to_list(rand:uniform()),
+    SnapshotName = File ++ RandVal,
+    SnapshotBlob = unicode:characters_to_binary(
+        io_lib:format("~tp.~n", [Snap])
+    ),
+    ok = file:write_file(SnapshotName, SnapshotBlob, [sync]),
+    ok = file:rename(SnapshotName, File).

--- a/apps/revault/test/dirmon_event_SUITE.erl
+++ b/apps/revault/test/dirmon_event_SUITE.erl
@@ -25,7 +25,8 @@ scan_with_timeouts(Config) ->
     gproc:reg({p, l, {?MODULE, ?FUNCTION_NAME}}),
     {ok, _} = revault_dirmon_event:start_link(
       {?MODULE, ?FUNCTION_NAME},
-      #{directory => PrivDir, poll_interval => 10}
+      #{directory => PrivDir, poll_interval => 10,
+        initial_sync => scan}
     ),
     ok = file:write_file(File, "text"),
     H0 = receive
@@ -55,7 +56,8 @@ survive_unexpected_msgs(Config) ->
     PrivDir = ?config(priv_dir, Config),
     {ok, Pid} = revault_dirmon_event:start_link(
       {?MODULE, ?FUNCTION_NAME},
-      #{directory => PrivDir, poll_interval => 1000000}
+      #{directory => PrivDir, poll_interval => 1000000,
+        initial_sync => scan}
     ),
     Pid ! make_ref(),
     gen_server:cast(Pid, make_ref()),

--- a/apps/revault/test/prop_dirmon_event_statem.erl
+++ b/apps/revault/test/prop_dirmon_event_statem.erl
@@ -30,6 +30,7 @@ prop_test() ->
                 {ok, _} = revault_dirmon_event:start_link(
                     ?LISTENER_NAME,
                     #{directory => ?DIR,
+                      initial_sync => scan,
                       poll_interval => 6000000} % too long to interfere
                 ),
                 Listener = spawn_link(fun listener/0),

--- a/test/boot_SUITE.erl
+++ b/test/boot_SUITE.erl
@@ -2,7 +2,7 @@
 -module(boot_SUITE).
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 all() ->
     [start_stop].


### PR DESCRIPTION
The event tracker can now optionally save and restore its state from
disk for all the versions it knows of.

The event monitor itself is augmented to support two modes for its
initial scanning: one that is stateless and supports essentially the
existing mode (dubbed `scan`), meaning that on first boot it scans and
goes forward, and a second mode (`tracker`) that uses the shared name
the tracker should have to go ask for all the files and move forwards.

Without the tracker mode, the failure of either component would be
sufficient to ensure that on a restart, events are missed and never
recovered. With it, each restart is now safe to re-discover missed state
since the last boot. It's a bit obtuse, but preferable to both modules
tracking their own state on disk since then we'd need to provide a
consistent cut.

Addresses #13 