### PR TITLE
Don't accidentally initialize a FSM

### DIFF
--- a/apps/revault/src/revault_fsm.erl
+++ b/apps/revault/src/revault_fsm.erl
@@ -168,7 +168,7 @@ init({DbDir, Name, Path, Interval, Callback}) ->
 uninitialized(enter, _, Data) ->
     {keep_state, Data};
 uninitialized({call, From}, id, Data) ->
-    {next_state, initialized, Data, [{reply, From, undefined}]};
+    {next_state, uninitialized, Data, [{reply, From, undefined}]};
 uninitialized({call, From}, {role, server}, Data) ->
     %% Something external telling us we're gonna be in server mode
     {next_state, server_init, Data,

--- a/apps/revault/test/revault_fsm_SUITE.erl
+++ b/apps/revault/test/revault_fsm_SUITE.erl
@@ -256,6 +256,7 @@ client_no_server(Config) ->
         ?config(interval, Config),
         (?config(nohost_callback, Config))(Name)
     ),
+    ?assertEqual(undefined, revault_fsm:id(Name)),
     %% How to specify what sort of client we are? to which server?
     ok = revault_fsm:client(Name),
     ?assertEqual({error, busy}, revault_fsm:client(Name)),


### PR DESCRIPTION
This tiny typo would cause crashes, as invariants in the initialized state enter checks would detect an undefined ID in an initialized state and would die.

This is of course because a read-only check to an ID shouldn't turn the FSM into an internal initialized mode without going through actual initialization.