### PR TITLE
Fix maestro loader, auto-boot FSMs from config

### DIFF
--- a/apps/maestro/src/maestro_loader.erl
+++ b/apps/maestro/src/maestro_loader.erl
@@ -4,7 +4,7 @@
 -include_lib("kernel/include/logger.hrl").
 -define(RELOAD_INTERVAL, timer:minutes(5)).
 
--export([start_link/0]).
+-export([start_link/0, status/0]).
 -export([init/1,
          handle_call/3, handle_cast/2, handle_info/2, handle_continue/2,
          terminate/2]).
@@ -20,6 +20,9 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+status() ->
+    gen_server:call(?MODULE, status, 10000).
+
 %%%%%%%%%%%%%%%%%
 %%% CALLBACKS %%%
 %%%%%%%%%%%%%%%%%
@@ -27,6 +30,16 @@ init([]) ->
     CfgPath = maestro_cfg:config_path(),
     {ok, #state{cfg_path = CfgPath}, {continue, load_config}}.
 
+handle_call(status, _From, State=#state{cfg=Current, cfg_path=Path}) ->
+    case maestro_cfg:parse_file(Path) of
+        {ok, Current} ->
+            {reply, current, State};
+        {ok, _Other} ->
+            {reply, outdated, State};
+        {error, Reason} ->
+            handle_cfg_parse_error(Reason, Path),
+            {reply, last_valid, State}
+    end;
 handle_call(_Call, _From, State) ->
     {noreply, State}.
 
@@ -73,119 +86,82 @@ handle_cfg_parse_error(Reason, Path) ->
     }).
 
 apply_cfg(Cfg, undefined) ->
-    #{
-        <<"dirs">> := DirsMap,
-        <<"peers">> := PeersMap,
-        <<"server">> := #{<<"auth">> := ServersAuthMap}
-    } = Cfg,
-    %% We assume all directories are shared in some way,
-    %% either as a server or as a client. If we are the
-    %% client of anything, then we need to get our initial
-    %% data from another end. If we are the server of anything
-    %% then we can start first.
-    %% We can only start the tracker and give a hint to the
-    %% type for it to start the whole hierarchy.
-    %%
-    %% A server that isn't shared in any way is just started
-    %% as a disterl server, which shouldn't be visible to the
-    %% rest of the system but could be use for local syncs
-    %% and tests.
-    %%
-    %% At some point there's gonna be a non-disterl sync, which is
-    %% what is supported here, but for the time being, just
-    %% tunnel proc names and node names through; you can only
-    %% invent two telephones and then improve things.
-    Annotated = Cfg#{<<"dirs">> => annotate_dirs(DirsMap, ServersAuthMap, PeersMap)},
-    start_workers(Annotated).
+    start_workers(Cfg).
 
-annotate_dirs(DirsMap, ServersAuthMap, PeersMap) ->
-    maps:fold(fun(Dir, Map, Acc) ->
-            Acc#{Dir => maps:merge(Map, annotate_dir(Dir, ServersAuthMap, PeersMap))}
-        end,
-        #{},
-        DirsMap
-    ).
-
-start_workers(AnnotatedCfg) ->
-    #{
-        <<"db">> := #{<<"path">> := DbPath},
-        <<"dirs">> := DirsMap
-    } = AnnotatedCfg,
-    [begin
-         start_fsm(Dir, DbPath, Map),
-         %% What do we do if a directory is both a server and a client?
-         %% Should probably try to be a client first; the assumption
-         %% is that it could be a mirror that first needs to fetch its ID
-         %% and then can start serving data to other consumers.
-         %%
-         %% This implies that starting clients may block starting servers
-         %% for any worker, so long as no ID is found
-         %% TODO: change things such that starts are handled per-directory
-         %% so that we can block per-directory rather than per client vs. server
-         %% set. This would however still mess with the config reloading
-         %% functionality.
-         start_clients(Dir, Map),
-         start_servers(Dir, Map)
-     end || {Dir, Map} <- maps:to_list(DirsMap)],
+start_workers(Cfg) ->
+    %% start all clients first, with each client call trying to boot its own VM
+    %% and assert a client mode;
+    %% then start all servers, with each server call trying to boot its own VM
+    %% and expecting to get a busy call in some cases when asserting the mode.
+    %% This order ensures that a directory that is marked both as a client and
+    %% a server (maybe because the user wants it to play both roles) is always
+    %% hydrated from another server first, to avoid split leadership and id
+    %% conflicts.
+    start_clients(Cfg),
+    start_servers(Cfg),
     ok.
 
-annotate_dir(Dir, ServersAuthMap, PeersMap) ->
-    maps:merge_with(fun(_, M1, M2) -> maps:merge(M1, M2) end,
-                    annotate_servers(Dir, ServersAuthMap),
-                    annotate_peers(Dir, PeersMap)).
-
-annotate_servers(Dir, ServersAuthMap) ->
-    maps:fold(
-      fun(<<"tls">>, V=#{<<"authorized">> := Map}, M) ->
-              List = lists:append([maps:get(<<"sync">>, Opts)
-                                   || {_, Opts} <- maps:to_list(Map)]),
-            case lists:member(Dir, List) of
-                true ->
-                    maps:update_with(<<"server">>, fun(L) -> [{<<"tls">>, V}|L] end,
-                                     [{<<"tls">>, V}], M);
-                false ->
-                    M
-            end;
-          (Type, V=#{<<"sync">> := List}, M) ->
-            case lists:member(Dir, List) of
-                true ->
-                    maps:update_with(<<"server">>, fun(L) -> [{Type, V}|L] end,
-                                     [{Type, V}], M);
-                false ->
-                    M
-            end
-        end,
-        #{},
-        ServersAuthMap
-    ).
-
-annotate_peers(Dir, PeersMap) ->
-    maps:fold(fun(PeerName, V=#{<<"sync">> := List}, M) ->
-            case lists:member(Dir, List) of
-                true ->
-                    maps:update_with(<<"peers">>, fun(L) -> [{PeerName, V}|L] end,
-                                     [{PeerName, V}], M);
-                false ->
-                    M
-            end
-        end,
-        #{},
-        PeersMap
-    ).
-
-
-start_fsm(Name, DbDir, #{<<"path">> := Path, <<"interval">> := Interval}) ->
-    revault_fsm_sup:start_fsm(DbDir, Name, Path, Interval).
-
-start_servers(_Name, _TypeMaps) ->
-    %% If disterl type, do ensure erlang nodes are connected? The FSMs should
-    %% be able to ensure that on their own though.
+start_clients(Cfg = #{<<"peers">> := PeersMap}) ->
+    [start_client(Dir, Cfg, PeerName, PeerCfg)
+     || {PeerName, PeerCfg = #{<<"sync">> := DirList}} <- maps:to_list(PeersMap),
+        Dir <- DirList],
     ok.
 
-start_clients(_Name, _PeerMaps) ->
+start_client(DirName,
+             Cfg=#{<<"db">> := #{<<"path">> := DbDir}, <<"dirs">> := DirsMap},
+             PeerName, PeerCfg) ->
+    #{DirName := #{<<"interval">> := Interval,
+                   <<"path">> := Path}} = DirsMap,
     %% Clients can depend on multiple peers, which can all be valid;
     %% it's possible that only one of the many peers is available at
     %% first. We can try to connect to all of them, and if none is
     %% available, we can't actually get started unless an ID already
     %% existed locally.
+    #{<<"auth">> := #{<<"type">> := AuthType}} = PeerCfg,
+    Cb = (callback_mod(AuthType)):callback({DirName, Cfg}),
+    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Interval, Cb),
+    case revault_fsm:id(DirName) of
+        undefined ->
+            ok = revault_fsm:client(DirName),
+            %% this call is allowed to fail if the peer isn't up at this
+            %% point in time, but will keep the FSM in client mode, which
+            %% we desire at this point.
+            _ = revault_fsm:id(DirName, PeerName),
+            ok;
+        _ ->
+            ok
+    end.
+
+start_servers(Cfg = #{<<"server">> := ServMap}) ->
+    %% Start TLS servers first for max security, then go lower to TCP,
+    %% at least until we figure out how to support many types at once.
+    AuthTypesMap = maps:get(<<"auth">>, ServMap, #{}),
+    TlsMap = maps:get(<<"tls">>, AuthTypesMap, #{}),
+    AuthMap = maps:get(<<"authorized">>, TlsMap, #{}),
+    TlsDirs = lists:usort(lists:append(
+        [maps:get(<<"sync">>, AuthCfg)
+         || {_Peer, AuthCfg} <- maps:to_list(AuthMap)]
+    )),
+    [start_server(Dir, Cfg, <<"tls">>) || Dir <- TlsDirs],
+    NoneMap = maps:get(<<"none">>, AuthTypesMap, #{}),
+    NoneDirs = lists:usort(maps:get(<<"sync">>, NoneMap, [])),
+    [start_server(Dir, Cfg, <<"none">>) || Dir <- NoneDirs],
     ok.
+
+start_server(DirName,
+             Cfg=#{<<"db">> := #{<<"path">> := DbDir}, <<"dirs">> := DirsMap},
+             Type) ->
+    #{DirName := #{<<"interval">> := Interval,
+                   <<"path">> := Path}} = DirsMap,
+    Cb = (callback_mod(Type)):callback({DirName, Cfg}),
+    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Interval, Cb),
+    case revault_fsm:id(DirName) of
+        undefined ->
+            ok = revault_fsm:server(DirName);
+        _ ->
+            ok
+    end.
+
+%% No pattern allows disterl to work as an option here. Only works for tests.
+callback_mod(<<"tls">>) -> revault_tls;
+callback_mod(<<"none">>) -> revault_tcp.

--- a/apps/revault/src/revault_tcp.erl
+++ b/apps/revault/src/revault_tcp.erl
@@ -14,27 +14,29 @@
 %% callbacks from within the FSM
 -export([callback/1, mode/2, peer/3, accept_peer/3, unpeer/3, send/3, reply/4, unpack/2]).
 
--record(state, {name, dirs, mode, serv_conn}).
+-record(state, {proc, name, dirs, mode, serv_conn}).
 -type state() :: term().
 -type cb_state() :: {?MODULE, state()}.
 -export_type([state/0]).
 
 -spec callback(term()) -> state().
 callback({Name, DirOpts}) ->
-    {?MODULE, #state{name=Name, dirs=DirOpts}}.
+    {?MODULE, #state{proc=Name, name=Name, dirs=DirOpts}};
+callback({Proc, Name, DirOpts}) ->
+    {?MODULE, #state{proc=Proc, name=Name, dirs=DirOpts}}.
 
 -spec mode(client|server, state()) -> {term(), cb_state()}.
-mode(Mode, S=#state{name=Name, dirs=DirOpts}) ->
+mode(Mode, S=#state{proc=Proc, dirs=DirOpts}) ->
     Res = case Mode of
         client ->
-            revault_protocols_tcp_sup:start_client(Name, DirOpts);
+            revault_protocols_tcp_sup:start_client(Proc, DirOpts);
         server ->
-            revault_protocols_tcp_sup:start_server(Name, DirOpts)
+            revault_protocols_tcp_sup:start_server(Proc, DirOpts)
     end,
     {Res, {?MODULE, S#state{mode=Mode}}}.
 
 %% @doc only callable from the client-side.
-peer(Local, Peer=Dir, S=#state{dirs=#{<<"peers">> := Peers}}) ->
+peer(Local, Peer, S=#state{name=Dir, dirs=#{<<"peers">> := Peers}}) ->
     case Peers of
         #{Peer := Map} ->
             Payload = {revault, make_ref(), revault_data_wrapper:peer(Dir)},
@@ -43,32 +45,32 @@ peer(Local, Peer=Dir, S=#state{dirs=#{<<"peers">> := Peers}}) ->
             {{error, unknown_peer}, {?MODULE, S}}
     end.
 
-accept_peer(Remote, Marker, S=#state{name=Name}) ->
-    {ok, Conn} = revault_tcp_serv:accept_peer(Name, Remote, Marker),
+accept_peer(Remote, Marker, S=#state{proc=Proc}) ->
+    {ok, Conn} = revault_tcp_serv:accept_peer(Proc, Remote, Marker),
     {ok, {?MODULE, S#state{serv_conn=Conn}}}.
 
-unpeer(Name, Remote, S=#state{mode=client}) ->
-    {revault_tcp_client:unpeer(Name, Remote),
+unpeer(Proc, Remote, S=#state{mode=client}) ->
+    {revault_tcp_client:unpeer(Proc, Remote),
      {?MODULE, S}};
-unpeer(Name, Remote, S=#state{mode=server, serv_conn=Conn}) ->
-    {revault_tcp_serv:unpeer(Name, Remote, Conn),
+unpeer(Proc, Remote, S=#state{mode=server, serv_conn=Conn}) ->
+    {revault_tcp_serv:unpeer(Proc, Remote, Conn),
      {?MODULE, S#state{serv_conn=undefined}}}.
 
 %% @doc only callable from the client-side, server always replies.
-send(Remote, Payload, S=#state{name=Name, mode=client}) ->
+send(Remote, Payload, S=#state{proc=Proc, mode=client}) ->
     Marker = make_ref(),
-    Res = case revault_tcp_client:send(Name, Remote, Marker, Payload) of
+    Res = case revault_tcp_client:send(Proc, Remote, Marker, Payload) of
         ok -> {ok, Marker};
         Other -> Other
     end,
     {Res, {?MODULE, S}}.
 
 % [Remote, Marker, revault_data_wrapper:ok()]),
-reply(Remote, Marker, Payload, S=#state{name=Name, mode=client}) ->
-    {revault_tcp_client:reply(Name, Remote, Marker, Payload),
+reply(Remote, Marker, Payload, S=#state{proc=Proc, mode=client}) ->
+    {revault_tcp_client:reply(Proc, Remote, Marker, Payload),
      {?MODULE, S}};
-reply(Remote, Marker, Payload, S=#state{name=Name, mode=server, serv_conn=Conn}) ->
-    {revault_tcp_serv:reply(Name, Remote, Conn, Marker, Payload),
+reply(Remote, Marker, Payload, S=#state{proc=Proc, mode=server, serv_conn=Conn}) ->
+    {revault_tcp_serv:reply(Proc, Remote, Conn, Marker, Payload),
      {?MODULE, S}}.
 
 unpack(_, _) -> error(undef).
@@ -114,5 +116,5 @@ unpack({conflict_file, ?VSN, WorkPath, Path, Count, Meta, Bin}) ->
 unpack(Term) ->
     Term.
 
-send_local(Name, Payload) ->
-    gproc:send({n, l, {revault_fsm, Name}}, Payload).
+send_local(Proc, Payload) ->
+    gproc:send({n, l, {revault_fsm, Proc}}, Payload).

--- a/apps/revault/test/revault_fsm_SUITE.erl
+++ b/apps/revault/test/revault_fsm_SUITE.erl
@@ -20,7 +20,7 @@ groups() ->
 
 init_per_group(tcp, Config) ->
     [{callback, fun(Name) ->
-        revault_tcp:callback({Name, #{
+        revault_tcp:callback({Name, <<"test">>, #{
             <<"peers">> => #{
                 <<"test">> => #{
                     <<"sync">> => [<<"test">>],
@@ -39,7 +39,7 @@ init_per_group(tcp, Config) ->
         }})
      end},
      {nohost_callback, fun(Name) ->
-        revault_tcp:callback({Name, #{
+        revault_tcp:callback({Name, <<"test">>, #{
             <<"peers">> => #{
                 <<"test">> => #{
                     <<"sync">> => [<<"test">>],
@@ -58,7 +58,7 @@ init_per_group(disterl, Config) ->
 init_per_group(tls, Config) ->
     CertDir = ?config(data_dir, Config),
     [{callback, fun(Name) ->
-        revault_tls:callback({Name, #{
+        revault_tls:callback({Name, <<"test">>, #{
             <<"peers">> => #{
                 <<"test">> => #{
                     <<"sync">> => [<<"test">>],
@@ -89,7 +89,7 @@ init_per_group(tls, Config) ->
         }})
     end},
     {nohost_callback, fun(Name) ->
-        revault_tls:callback({Name, #{
+        revault_tls:callback({Name, <<"test">>, #{
             <<"peers">> => #{
                 <<"test">> => #{
                     <<"sync">> => [<<"test">>],


### PR DESCRIPTION
Test highlights an issue in TLS validation where the tests for revault_fsm rely on local names to make things work but that name doubles as the directory name being monitored and won't fit with the purposes of messaging _and_ in-band validation.

So the callback now allows overriding that on demand to make the internal tests work, and holds true for general defaults.

With this, the maestro loader initialization shows an end-to-end exchange over TLS using two distinct nodes.