### PR TITLE
Refactor conflict file handling

### DIFF
--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -10,7 +10,13 @@ permissions:
   contents: read
 
 env:
+  # Allow unicode output and enable features such as the maybe expression
   ERL_AFLAGS: +pc unicode -enable-feature all
+  # github actions does not have a shared filesystem between
+  # working files, the /tmp directory, or the ~/.cache directory
+  REVAULT_TMPDIR: ./tmp
+  # Force UTF-8 support since we need that for safe tests around
+  # roundtrip encoding.
   LANG: C.UTF-8
   LC_ALL: C.UTF-8
   LC_CTYPE: C.UTF-8

--- a/apps/maestro/test/session_SUITE.erl
+++ b/apps/maestro/test/session_SUITE.erl
@@ -81,6 +81,9 @@ end_per_testcase(_, Config) ->
     peer:stop(PidB),
     Config.
 
+setup_works() ->
+    [{doc, "The initialized peer nodes are running valid initialized FSMs"},
+     {timetrap, timer:seconds(5)}].
 setup_works(Config) ->
     {_, ServerNode} = ?config(peer_a, Config),
     {_, ClientNode} = ?config(peer_b, Config),
@@ -89,7 +92,9 @@ setup_works(Config) ->
     ok = init_client(ClientNode, Dir, <<"a">>),
     ok.
 
-%% No conflicts in this one yet
+copy_and_sync() ->
+    [{doc, "Copying files end-to-end works fine, with conflicts omitted."},
+     {timetrap, timer:seconds(5)}].
 copy_and_sync(Config) ->
     {_, _ServerNode} = ?config(peer_a, Config),
     {_, ClientNode} = ?config(peer_b, Config),
@@ -111,6 +116,10 @@ copy_and_sync(Config) ->
     ?assertEqual(tree(DirA), tree(DirB)),
     ok.
 
+conflict_and_sync() ->
+    [{doc, "Copying files end-to-end works fine, including conflicts "
+           "and resolution."},
+     {timetrap, timer:seconds(5)}].
 conflict_and_sync(Config) ->
     {_, ServerNode} = ?config(peer_a, Config),
     {_, ClientNode} = ?config(peer_b, Config),

--- a/apps/revault/src/revault.app.src
+++ b/apps/revault/src/revault.app.src
@@ -11,7 +11,7 @@
     uuid,
     ssl, public_key, tak
    ]},
-  {env,[]},
+  {env, []},
   {modules, []},
 
   {maintainers, ["Fred Hebert"]},

--- a/apps/revault/src/revault_conflict_file.erl
+++ b/apps/revault/src/revault_conflict_file.erl
@@ -1,0 +1,76 @@
+%%% @private This module contains utility functions around the manipulation
+%%% of conflict files and naming schemes that end up being shared by
+%%% a few modules (eg. `revault_dirmon_tracker' and `revault_fsm') and may
+%%% require shared functionality, or easier interfacing for testing purposes.
+%%% @end
+-module(revault_conflict_file).
+-export([marker/1, conflicting/2, working/1, hex/1, hexname/1]).
+
+%% @doc create a conflict file name.
+-spec marker(file:filename_all()) -> file:filename_all().
+marker(Path) ->
+    revault_file:extension(Path, ".conflict").
+
+%% @doc create a conflicting version of a file name. Expects to receive
+%% the hash.
+-spec conflicting(file:filename_all(), binary()) -> file:filename_all().
+conflicting(Path, Hash) ->
+    revault_file:extension(Path, "." ++ hexname(Hash)).
+
+%% @doc returns whether the current path may hint at a conflict file, and
+%% if so, which working file is at its source.
+-spec working(file:filename_all()) -> {marker | conflicting, file:filename_all()}
+                                    | undefined.
+working(Path) ->
+    working(Path, filename:extension(Path)).
+
+
+%% @doc turn a byte sequence into a hexadecimal representation
+-spec hex(binary()) -> <<_:_*16>>.
+hex(Hash) ->
+    binary:encode_hex(Hash).
+
+%% @doc turn a byte sequence into a subset of a hex representation
+%% that can be used as a file path suffix for conflict files
+-spec hexname(binary()) -> list().
+hexname(Hash) ->
+    %% This assertion makes gradualizer happy.
+    Res = [_|_] = unicode:characters_to_list(string:slice(hex(Hash), 0, 8)),
+    Res.
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+working(File, Ext) when Ext == ".conflict"; Ext == <<".conflict">> ->
+    {marker, drop_suffix(File, Ext)};
+working(File, Ext) ->
+    case string:length(Ext) == 9 andalso is_hex(drop_period(Ext)) of
+        true ->
+            {conflicting, drop_suffix(File, Ext)};
+        _ ->
+            undefined
+    end.
+
+drop_suffix(Path, Suffix) ->
+    case string:split(Path, Suffix, trailing) of
+        [Prefix, Tail] when Tail == <<>>; Tail == [] -> Prefix;
+        _ -> Path
+    end.
+
+drop_period(Ext) ->
+    case string:next_grapheme(Ext) of
+        [$.|Rest] -> Rest;
+        _ -> error({invalid_ext, Ext})
+    end.
+
+is_hex(Str) ->
+    case string:next_grapheme(Str) of
+        [C|T] when C >= $A, C =< $F; C >= $0, C =< $9 ->
+            case T of
+                [] -> true;
+                <<>> -> true;
+                _ -> is_hex(T)
+            end;
+        _ -> false
+    end.
+

--- a/apps/revault/src/revault_file.erl
+++ b/apps/revault/src/revault_file.erl
@@ -1,6 +1,12 @@
 -module(revault_file).
--export([make_relative/2]).
+-export([make_relative/2, copy/2, extension/2]).
 
+%% @doc makes path `File' relative to `Dir', such that if you pass in
+%% `/a/b/c/d.txt' and the `Dir' path `/a/b', you get `c/d.txt'.
+-spec make_relative(Dir, File) -> Rel
+    when Dir :: file:filename_all(),
+         File :: file:filename_all(),
+         Rel :: file:filename_all().
 make_relative(Dir, File) ->
     do_make_relative_path(filename:split(Dir), filename:split(File)).
 
@@ -8,3 +14,42 @@ do_make_relative_path([H|T1], [H|T2]) ->
     do_make_relative_path(T1, T2);
 do_make_relative_path([], Target) ->
     filename:join(Target).
+
+%% @doc copies a file from a path `From' to location `To'. Uses a
+%% temporary file that then gets renamed to the final location in order
+%% to avoid issues in cases of crashes. If the `/tmp' directory is on
+%% a different filesystem, this behavior is going to fail and different
+%% `TMPDIR' must be configured.
+%% @end
+%% TODO: write a test on boot for this behavior?
+-spec copy(From, To) -> ok | {error, file:posix()}
+    when From :: file:filename_all(),
+         To :: file:filename_all().
+copy(From, To) ->
+    RandVal = float_to_list(rand:uniform()),
+    TmpFile = filename:join([system_tmpdir(), RandVal]),
+    ok = filelib:ensure_dir(TmpFile),
+    ok = filelib:ensure_dir(To),
+    {ok, _} = file:copy(From, TmpFile),
+    file:rename(TmpFile, To).
+
+%% @doc appends an extensino `Ext' to a path `Path' in a safe manner
+%% considering the possible types of `file:filename_all()' as a datatype.
+%% A sort of counterpart to `filename:extension/1'.
+-spec extension(file:filename_all(), string()) -> file:filename_all().
+extension(Path, Ext) when is_list(Path) ->
+    Path ++ Ext;
+extension(Path, Ext) when is_binary(Path) ->
+    BinExt = <<_/binary>> = unicode:characters_to_binary(Ext),
+    <<Path/binary, BinExt/binary>>.
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
+system_tmpdir() ->
+    case erlang:system_info(system_architecture) of
+        "win32" ->
+            filename:join([filename:basedir(user_cache, "revault"), "tmp"]);
+        _SysArch ->
+            os:getenv("TMPDIR", "/tmp")
+    end.

--- a/apps/revault/src/revault_fsm.erl
+++ b/apps/revault/src/revault_fsm.erl
@@ -695,7 +695,7 @@ do_handle_file_sync(Name, Id, F, Meta = {Vsn, Hash}, Bin) ->
         {LVsn, _HashOrStatus} ->
             case compare(Id, LVsn, Vsn) of
                 conflict ->
-                    FHash = make_conflict_path(F, Hash),
+                    FHash = revault_conflict_file:conflicting(F, Hash),
                     TmpF = filename:join("/tmp", FHash),
                     file:write_file(TmpF, Bin),
                     revault_dirmon_tracker:conflict(Name, F, TmpF, Meta),
@@ -727,7 +727,7 @@ handle_file_demand(F, Marker, Data=#data{name=Name, path=Path, callback=Cb1,
             %% TODO: optimize to better read and send file parts
             {Cb2, _} = lists:foldl(
                 fun(Hash, {CbAcc1, Ct}) ->
-                    FHash = make_conflict_path(F, Hash),
+                    FHash = revault_conflict_file:conflicting(F, Hash),
                     {ok, Bin} = file:read_file(filename:join(Path, FHash)),
                     NewPayload = revault_data_wrapper:send_conflict_file(F, FHash, Ct, {Vsn, Hash}, Bin),
                     %% TODO: track failing or succeeding transfers?
@@ -747,22 +747,3 @@ handle_file_demand(F, Marker, Data=#data{name=Name, path=Path, callback=Cb1,
             {ok, Cb2} = apply_cb(Cb1, reply, [R, Marker, NewPayload]),
             Data#data{callback=Cb2}
     end.
-
-make_conflict_path(F, Hash) ->
-    extension(F, "." ++ hexname(Hash)).
-
-%% TODO: extract shared definition with revault_dirmon_tracker
-hex(Hash) ->
-    binary:encode_hex(Hash).
-
-%% TODO: extract shared definition with revault_dirmon_tracker
-hexname(Hash) ->
-    unicode:characters_to_list(string:slice(hex(Hash), 0, 8)).
-
-%% TODO: extract shared definition with revault_dirmon_tracker
--spec extension(file:filename_all(), string()) -> file:filename_all().
-extension(Path, Ext) when is_list(Path) ->
-    Path ++ Ext;
-extension(Path, Ext) when is_binary(Path) ->
-    BinExt = <<_/binary>> = unicode:characters_to_binary(Ext),
-    <<Path/binary, BinExt/binary>>.

--- a/apps/revault/src/revault_fsm.erl
+++ b/apps/revault/src/revault_fsm.erl
@@ -467,7 +467,7 @@ client_sync_files(info, {revault, _Marker, {file, F, Meta, Bin}}, Data) ->
 client_sync_files(info, {revault, _Marker, {conflict_file, WorkF, F, CountLeft, Meta, Bin}}, Data) ->
     #data{name=Name, sub=S=#client_sync{acc=Acc}} = Data,
     %% TODO: handle the file being corrupted vs its own hash
-    TmpF = filename:join("/tmp", F),
+    TmpF = revault_file:tmp(F),
     filelib:ensure_dir(TmpF),
     ok = file:write_file(TmpF, Bin),
     revault_dirmon_tracker:conflict(Name, WorkF, TmpF, Meta),
@@ -558,7 +558,7 @@ server_sync_files(info, {revault, _Marker, {file, F, Meta, Bin}},
     {keep_state, Data};
 server_sync_files(info, {revault, _M, {conflict_file, WorkF, F, _CountLeft, Meta, Bin}}, Data) ->
     %% TODO: handle the file being corrupted vs its own hash
-    TmpF = filename:join("/tmp", F),
+    TmpF = revault_file:tmp(F),
     filelib:ensure_dir(TmpF),
     ok = file:write_file(TmpF, Bin),
     revault_dirmon_tracker:conflict(Data#data.name, WorkF, TmpF, Meta),
@@ -696,7 +696,7 @@ do_handle_file_sync(Name, Id, F, Meta = {Vsn, Hash}, Bin) ->
             case compare(Id, LVsn, Vsn) of
                 conflict ->
                     FHash = revault_conflict_file:conflicting(F, Hash),
-                    TmpF = filename:join("/tmp", FHash),
+                    TmpF = revault_file:tmp(FHash),
                     file:write_file(TmpF, Bin),
                     revault_dirmon_tracker:conflict(Name, F, TmpF, Meta),
                     file:delete(TmpF);
@@ -706,7 +706,7 @@ do_handle_file_sync(Name, Id, F, Meta = {Vsn, Hash}, Bin) ->
     end.
 
 update_file(Name, F, Meta, Bin) ->
-    TmpF = filename:join("/tmp", F),
+    TmpF = revault_file:tmp(F),
     filelib:ensure_dir(TmpF),
     ok = file:write_file(TmpF, Bin),
     revault_dirmon_tracker:update_file(Name, F, TmpF, Meta),


### PR DESCRIPTION
Some code was shared and misnomed conventions so this centers it all in a few files. Also replaces some unsafe copy operations with safer copy+rename ones from temporary directories.