### PR TITLE
Add a per-lineage UUID check

### DIFF
--- a/apps/revault/src/revault_data_wrapper.erl
+++ b/apps/revault/src/revault_data_wrapper.erl
@@ -9,13 +9,16 @@
 %%% This implies that the ID will be stored somewhere stateful, but the
 %%% protocol here does not need to know where or how.
 -module(revault_data_wrapper).
--export([peer/1, new/0, ask/0, ok/0, error/1, fork/1]).
+-export([peer/1, peer/2, new/0, ask/0, ok/0, error/1, fork/2]).
 -export([manifest/0, manifest/1, send_file/4, send_conflict_file/5, fetch_file/1,
          sync_complete/0]).
 -define(VSN, 1).
 
 peer(Remote) ->
     {peer, ?VSN, Remote}.
+
+peer(Remote, UUID) ->
+    {peer, ?VSN, Remote, UUID}.
 
 new() ->
     revault_id:new().
@@ -44,6 +47,6 @@ sync_complete() ->
 ok() -> {ok, ?VSN}.
 error(R) -> {error, ?VSN, R}.
 
-fork(Id) ->
+fork(Id, UUID) ->
     {Keep, Send} = revault_id:fork(Id),
-    {Keep, {reply, Send}}.
+    {Keep, {reply, {Send, UUID}}}.

--- a/apps/revault/src/revault_tls.erl
+++ b/apps/revault/src/revault_tls.erl
@@ -13,7 +13,7 @@
 %% are not generic.
 -export([wrap/1, unwrap/1, send_local/2]).
 %% callbacks from within the FSM
--export([callback/1, mode/2, peer/3, accept_peer/3, unpeer/3, send/3, reply/4, unpack/2]).
+-export([callback/1, mode/2, peer/3, peer/4, accept_peer/3, unpeer/3, send/3, reply/4, unpack/2]).
 %% shared functions
 -export([pin_certfile_opts/1, pin_certfiles_opts/1, make_selfsigned_cert/2]).
 
@@ -43,6 +43,15 @@ peer(Local, Peer, S=#state{name=Dir, dirs=#{<<"peers">> := Peers}}) ->
     case Peers of
         #{Peer := Map} ->
             Payload = {revault, make_ref(), revault_data_wrapper:peer(Dir)},
+            {revault_tls_client:peer(Local, Peer, Map, Payload), {?MODULE, S}};
+        _ ->
+            {{error, unknown_peer}, {?MODULE, S}}
+    end.
+
+peer(Local, Peer, UUID, S=#state{name=Dir, dirs=#{<<"peers">> := Peers}}) ->
+    case Peers of
+        #{Peer := Map} ->
+            Payload = {revault, make_ref(), revault_data_wrapper:peer(Dir, UUID)},
             {revault_tls_client:peer(Local, Peer, Map, Payload), {?MODULE, S}};
         _ ->
             {{error, unknown_peer}, {?MODULE, S}}
@@ -106,6 +115,7 @@ unwrap(<<_/binary>>) ->
     {error, incomplete}.
 
 unpack({peer, ?VSN, Remote}) -> {peer, Remote};
+unpack({peer, ?VSN, Remote, UUID}) -> {peer, Remote, UUID};
 unpack({ask, ?VSN}) -> ask;
 unpack({ok, ?VSN}) -> ok;
 unpack({error, ?VSN, R}) -> {error, R};

--- a/apps/revault/test/id_shim.erl
+++ b/apps/revault/test/id_shim.erl
@@ -4,6 +4,8 @@
          id_ask/2, id_reply/3, inspect_id/1]).
 -export([init/1, handle_call/3]).
 
+-define(UUID, <<158,169,164,144,204,120,74,163,181,249,87,231,157,44,17, 176>>).
+
 %% Fixtures for each test iteration, setting up and tearing down
 %% state.
 start_link() ->
@@ -25,9 +27,9 @@ id_ask(From, _To) ->
 
 id_reply(From, To, Id) ->
     _Msg = gen_server:call(To, {get, id_ask}),
-    {Keep, Resp} = revault_data_wrapper:fork(gen_server:call(From, {get, id})),
+    {Keep, Resp} = revault_data_wrapper:fork(gen_server:call(From, {get, id}), ?UUID),
     gen_server:call(From, {set, id, Keep}),
-    {reply, Id} = Resp,
+    {reply, {Id,_UUID}} = Resp,
     gen_server:call(To, {set, id, Id}),
     ok.
 


### PR DESCRIPTION
Each server once booting for the first time sets up a UUID. This UUID is passed around along with the ID upon a fork operation, such that all peers that are part of a network share the same UUID.

This is a minimal check done freely by the client (which is trusted via certs in the case of TLS, but is totally unauthentified in the case of TCP and disterl) which sends in its own UUID to the server when establishing a connection.

The server checks that UUID against its own, and if it notices a clash, it will bail out of the connection and refuse seeing it established.

The main objective of this is to prevent the accidental case where you misconfigure a client and make it talk to an unintended server and then accidentally start corrupting stuff by having broken ID ranges and unexpected files moving around.

This is _not_ a security feature because the trust model here would let a peer just send an unchecked message (by omitting the UUID, since that's a thing needed for the first connection) and bypass the whole thing anyway.

If we wanted to grow the threat model there, we'd need to divide the state machine of the server's side into two new halves (UUID submitted vs. no UUID submitted) and restrict operations that can be done unauthentified. This isn't the expected model here however and we don't cover that element since it assumes you've leaked your keys already and welp, not much you can do to protect against damage once this is done.