### PR TITLE
Fix real world usage

### DIFF
--- a/apps/revault/src/revault_file.erl
+++ b/apps/revault/src/revault_file.erl
@@ -72,9 +72,12 @@ system_tmpdir() ->
         undefined ->
             case os:getenv("REVAULT_TMPDIR") of
                 false ->
-                    application:set_env(revault, system_tmpdir, detect_tmpdir());
+                    Path = detect_tmpdir(),
+                    application:set_env(revault, system_tmpdir, Path),
+                    Path;
                 Path ->
-                    application:set_env(revault, system_tmpdir, Path)
+                    application:set_env(revault, system_tmpdir, Path),
+                    Path
             end
     end.
 

--- a/apps/revault/src/revault_fsm.erl
+++ b/apps/revault/src/revault_fsm.erl
@@ -111,6 +111,11 @@
                | #client_sync{} | #server{}
         }).
 
+-ifdef(TEST).
+-define(DEBUG_OPTS, [{debug, [trace]}]).
+-else.
+-define(DEBUG_OPTS, []).
+-endif.
 
 %  [dirs.images]
 %  interval = 60
@@ -120,7 +125,7 @@ start_link(DbDir, Name, Path, Interval) ->
     start_link(DbDir, Name, Path, Interval, revault_disterl).
 
 start_link(DbDir, Name, Path, Interval, Callback) ->
-    gen_statem:start_link(?registry(Name), ?MODULE, {DbDir, Name, Path, Interval, Callback}, [{debug, [trace]}]).
+    gen_statem:start_link(?registry(Name), ?MODULE, {DbDir, Name, Path, Interval, Callback}, ?DEBUG_OPTS).
 
 -spec server(name()) -> ok | {error, busy}.
 server(Name) ->
@@ -360,7 +365,8 @@ client_id_sync(info, {revault, Marker, {reply, {NewId,UUID}}},
 client_id_sync(_, _, Data) ->
     {keep_state, Data, [postpone]}.
 
-initialized(enter, _, Data=#data{}) ->
+initialized(enter, _, Data=#data{name=Name, id=Id, path=Path, interval=Interval, db_dir=DbDir}) ->
+    _ = start_tracker(Name, Id, Path, Interval, DbDir),
     {keep_state, Data};
 initialized({call, From}, id, Data=#data{id=Id}) ->
     {keep_state, Data, [{reply, From, {ok, Id}}]};

--- a/apps/revault/src/revault_protocols_tcp_sup.erl
+++ b/apps/revault/src/revault_protocols_tcp_sup.erl
@@ -9,7 +9,7 @@
 
 %% API
 -export([start_link/0,
-         start_server/2, start_server/3,
+         start_server/1, start_server/2,
          start_client/2, start_client/3]).
 
 %% Supervisor callbacks
@@ -30,11 +30,11 @@ start_client(Name, DirOpts) ->
 start_client(Name, DirOpts, TcpOpts) ->
     start_child(revault_tcp_client, Name, [Name, DirOpts, TcpOpts]).
 
-start_server(Name, DirOpts) ->
-    start_child(revault_tcp_serv, Name, [Name, DirOpts]).
+start_server(DirOpts) ->
+    start_child(revault_tcp_serv, shared, [DirOpts]).
 
-start_server(Name, DirOpts, TcpOpts) ->
-    start_child(revault_tcp_serv, Name, [Name, DirOpts, TcpOpts]).
+start_server(DirOpts, TcpOpts) ->
+    start_child(revault_tcp_serv, shared, [DirOpts, TcpOpts]).
 
 %%====================================================================
 %% Supervisor callbacks

--- a/apps/revault/src/revault_protocols_tls_sup.erl
+++ b/apps/revault/src/revault_protocols_tls_sup.erl
@@ -9,7 +9,7 @@
 
 %% API
 -export([start_link/0,
-         start_server/2, start_server/3,
+         start_server/1, start_server/2,
          start_client/2, start_client/3]).
 
 %% Supervisor callbacks
@@ -30,11 +30,11 @@ start_client(Name, DirOpts) ->
 start_client(Name, DirOpts, TcpOpts) ->
     start_child(revault_tls_client, Name, [Name, DirOpts, TcpOpts]).
 
-start_server(Name, DirOpts) ->
-    start_child(revault_tls_serv, Name, [Name, DirOpts]).
+start_server(DirOpts) ->
+    start_child(revault_tls_serv, shared, [DirOpts]).
 
-start_server(Name, DirOpts, TcpOpts) ->
-    start_child(revault_tls_serv, Name, [Name, DirOpts, TcpOpts]).
+start_server(DirOpts, TcpOpts) ->
+    start_child(revault_tls_serv, shared, [DirOpts, TcpOpts]).
 
 %%====================================================================
 %% Supervisor callbacks

--- a/apps/revault/src/revault_tcp.hrl
+++ b/apps/revault/src/revault_tcp.hrl
@@ -2,8 +2,8 @@
 %% within revault.
 -define(VSN, 1).
 -define(ACCEPT_WAIT, 100).
--define(SERVER(Name), {via, gproc, {n, l, {tcp, serv, Name}}}).
+-define(SERVER, {via, gproc, {n, l, {tcp, serv, shared}}}).
 -define(CLIENT(Name), {via, gproc, {n, l, {tcp, client, Name}}}).
 -record(client, {name, dirs, dir, auth, opts, sock, buf = <<>>}).
--record(serv, {name, dirs, opts, sock, acceptor, workers=#{}}).
+-record(serv, {names=#{}, dirs, opts, sock, acceptor, workers=#{}}).
 -record(conn, {localname, sock, dirs, buf = <<>>}).

--- a/apps/revault/src/revault_tls.erl
+++ b/apps/revault/src/revault_tls.erl
@@ -34,8 +34,6 @@ mode(Mode, S=#state{proc=Proc, name=Name, dirs=DirOpts}) ->
         client ->
             revault_protocols_tls_sup:start_client(Proc, DirOpts);
         server ->
-            %% ensure_server
-            %% add_server_mapping(Name,Proc)
             %% Assumes that all servers have the full DirOpts view if this is the
             %% first place to start it.
             case revault_protocols_tls_sup:start_server(DirOpts) of

--- a/apps/revault/src/revault_tls.erl
+++ b/apps/revault/src/revault_tls.erl
@@ -29,12 +29,23 @@ callback({Proc, Name, DirOpts}) ->
     {?MODULE, #state{proc=Proc, name=Name, dirs=DirOpts}}.
 
 -spec mode(client|server, state()) -> {term(), cb_state()}.
-mode(Mode, S=#state{proc=Proc, dirs=DirOpts}) ->
+mode(Mode, S=#state{proc=Proc, name=Name, dirs=DirOpts}) ->
     Res = case Mode of
         client ->
             revault_protocols_tls_sup:start_client(Proc, DirOpts);
         server ->
-            revault_protocols_tls_sup:start_server(Proc, DirOpts)
+            %% ensure_server
+            %% add_server_mapping(Name,Proc)
+            %% Assumes that all servers have the full DirOpts view if this is the
+            %% first place to start it.
+            case revault_protocols_tls_sup:start_server(DirOpts) of
+                {ok, Pid} ->
+                    revault_tls_serv:map(Name, Proc),
+                    {ok, Pid};
+                {error, {already_started, Pid}} ->
+                    revault_tls_serv:map(Name, Proc),
+                    {ok, Pid}
+            end
     end,
     {Res, {?MODULE, S#state{mode=Mode}}}.
 

--- a/apps/revault/src/revault_tls.hrl
+++ b/apps/revault/src/revault_tls.hrl
@@ -3,9 +3,9 @@
 -define(VSN, 1).
 -define(ACCEPT_WAIT, 100). % interval for accept loops
 -define(HANDSHAKE_WAIT, 10000). % give up after 10 seconds
--define(SERVER(Name), {via, gproc, {n, l, {tls, serv, Name}}}).
+-define(SERVER, {via, gproc, {n, l, {tls, serv, shared}}}).
 -define(CLIENT(Name), {via, gproc, {n, l, {tls, client, Name}}}).
 -record(client, {name, dirs, dir, auth, opts, sock, buf = <<>>}).
--record(serv, {name, dirs, opts, sock, acceptor, workers=#{}}).
+-record(serv, {names=#{}, dirs, opts, sock, acceptor, workers=#{}}).
 -record(conn, {localname, sock, dirs, buf = <<>>}).
 

--- a/apps/revault/test/revault_fsm_SUITE.erl
+++ b/apps/revault/test/revault_fsm_SUITE.erl
@@ -239,6 +239,9 @@ client_id(Config) ->
         ?config(path, Config),
         ?config(interval, Config)
     ),
+    %% See that we have a tracker going even without defining a role
+    wait_alive([{n,l, {revault_dirmon_tracker, Name}}]),
+    %% Define a role
     ok = revault_fsm:client(Name),
     ?assertEqual({ok, ClientId}, revault_fsm:id(Name)),
     unlink(Pid),
@@ -650,4 +653,23 @@ wait_dead([Name|Rest]) when is_atom(Name) ->
         _ ->
             timer:sleep(100),
             wait_dead([Name|Rest])
+    end.
+
+wait_alive([]) ->
+    ok;
+wait_alive([Name|Rest]) when is_atom(Name) ->
+    case whereis(Name) of
+        undefined ->
+            timer:sleep(100),
+            wait_alive([Name|Rest]);
+        _ ->
+            wait_alive(Rest)
+    end;
+wait_alive([Name|Rest]) ->
+    case gproc:where(Name) of
+        undefined ->
+            timer:sleep(100),
+            wait_alive([Name|Rest]);
+        _ ->
+            wait_alive(Rest)
     end.

--- a/cli/revault_cli/src/revault_cli.erl
+++ b/cli/revault_cli/src/revault_cli.erl
@@ -8,7 +8,7 @@
 
 
 %% Name of the main running host, as specified in `config/vm.args'
--define(DEFAULT_NODE, 'revault@127.0.0.1').
+-define(DEFAULT_NODE, "revault@" ++ hd(tl(string:tokens(atom_to_list(node()), "@")))).
 
 %%====================================================================
 %% API functions
@@ -22,13 +22,13 @@ cli() ->
     #{commands => #{
         "list" => #{
             arguments => [
-                #{name => node, nargs => 'maybe', type => atom, default => ?DEFAULT_NODE,
+                #{name => node, nargs => 'maybe', type => {string, ".*@.*"}, default => ?DEFAULT_NODE,
                   long => "node", help => "ReVault instance to connect to"}
             ]
         },
         "scan" => #{
             arguments => [
-                #{name => node, nargs => 'maybe', type => atom, default => ?DEFAULT_NODE,
+                #{name => node, nargs => 'maybe', type => {string, ".*@.*"}, default => ?DEFAULT_NODE,
                   long => "node", help => "ReVault instance to connect to"},
                 #{name => dirs, long => "dirs",
                   nargs => nonempty_list, type => binary, help => "Name of the directory to scan"}
@@ -36,7 +36,7 @@ cli() ->
         },
         "sync" => #{
             arguments => [
-                #{name => node, nargs => 'maybe', type => atom, default => ?DEFAULT_NODE,
+                #{name => node, nargs => 'maybe', type => {string, ".*@.*"}, default => ?DEFAULT_NODE,
                   long => "node", help => "ReVault instance to connect to"},
                 #{name => peer, nargs => 1, type => binary,
                   long => "peer", help => "ReVault peer name with which to sync"},
@@ -46,14 +46,12 @@ cli() ->
         },
         "status" => #{
             arguments => [
-                #{name => node, nargs => 'maybe', type => atom, default => ?DEFAULT_NODE,
+                #{name => node, nargs => 'maybe', type => {string, ".*@.*"}, default => ?DEFAULT_NODE,
                   long => "node", help => "ReVault instance to connect to"}
             ]
         },
         "generate-keys" => #{
             arguments => [
-                #{name => node, nargs => 'maybe', type => atom, default => ?DEFAULT_NODE,
-                  long => "node", help => "ReVault instance to connect to"},
                 #{name => certname, nargs => 'maybe', long => "name",
                   type => string, default => "revault",
                   help => "Name of the key files generated"},
@@ -68,7 +66,8 @@ cli() ->
 %%%%%%%%%%%%%%%%%%%%%%%%
 %%% BEHAVIOR EXPORTS %%%
 %%%%%%%%%%%%%%%%%%%%%%%%
-list(#{node := Node}) ->
+list(#{node := NodeStr}) ->
+    Node = list_to_atom(NodeStr),
     maybe
         ok ?= connect(Node),
         ok ?= revault_node(Node),
@@ -80,7 +79,8 @@ list(#{node := Node}) ->
             io:format("Erlang distribution connection to ~p failed.~n", [Node])
     end.
 
-scan(_Args = #{node := Node, dirs := Dirs}) ->
+scan(_Args = #{node := NodeStr, dirs := Dirs}) ->
+    Node = list_to_atom(NodeStr),
     maybe
         ok ?= connect(Node),
         ok ?= revault_node(Node),
@@ -91,7 +91,8 @@ scan(_Args = #{node := Node, dirs := Dirs}) ->
         {error, connection_failed} ->
             io:format("Erlang distribution connection to ~p failed.~n", [Node])
     end;
-scan(Args = #{node := Node}) ->
+scan(Args = #{node := NodeStr}) ->
+    Node = list_to_atom(NodeStr),
     %% find all directories allowed
     maybe
         ok ?= connect(Node),
@@ -103,7 +104,8 @@ scan(Args = #{node := Node}) ->
     end.
 
 
-sync(#{node := Node, dirs := Dirs = [_|_], peer := Peer}) ->
+sync(#{node := NodeStr, dirs := Dirs = [_|_], peer := Peer}) ->
+    Node = list_to_atom(NodeStr),
     maybe
         ok ?= connect(Node),
         ok ?= revault_node(Node),

--- a/config/vm.args
+++ b/config/vm.args
@@ -1,4 +1,4 @@
--name revault@127.0.0.1
+-name revault
 
 -setcookie revault_cookie
 

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
         {escript_incl_apps, [revault_cli, argparse]},
         {escript_main_app, revault_cli},
         {escript_name, revault_cli},
-        {escript_emu_args, "%%! -name cli@127.0.0.1 -setcookie revault_cookie +sbtu +A1\n"}
+        {escript_emu_args, "%%! -name cli -setcookie revault_cookie +sbtu +A1\n"}
     ]},
     {test, [
         {relx, [{sys_config, "./config/test.sys.config"},


### PR DESCRIPTION
Finally got to the point where I tried this with IRL cross-computer syncs with a real config and found a few significant bugs:

- TLS as a server does require a central shared entry. I found a rework to keep the mapping going that makes sense.
- Drop debug output in non-test situations since it's really slowing things down massively
- fix the CLI only accepting existinng atoms, which is not useful for peer node names.
- uncover and fix a bug around how the tracker is started when not part of the full initialization from a fresh node.
- port that mapping and TLS split into the TCP config as well
- add a regression check for the tracker starting on initialized nodes.