### PR TITLE
Fix timer usage

### DIFF
--- a/apps/maestro/src/maestro_cfg.erl
+++ b/apps/maestro/src/maestro_cfg.erl
@@ -68,7 +68,7 @@ normalize_server(Map, Dirnames) ->
 normalize_dir(Key, Map, Acc) ->
     Acc#{Key => #{
            <<"interval">> => maps:get(<<"interval">>, Map,
-                                      ?DEFAULT_INTERVAL_SECONDS),
+                                      ?DEFAULT_INTERVAL_SECONDS)*1000,
            <<"path">> => maps:get(<<"path">>, Map),
            <<"ignore">> => maps:get(<<"ignore">>, Map, [])
           }

--- a/apps/maestro/test/cfg_SUITE.erl
+++ b/apps/maestro/test/cfg_SUITE.erl
@@ -26,12 +26,12 @@ literal(Config) ->
          },
          <<"dirs">> := #{
             <<"music">> := #{
-                <<"interval">> := 60,
+                <<"interval">> := 60000, % converted to ms
                 <<"path">> := <<"~/Music">>,
                 <<"ignore">> := []
             },
             <<"images">> := #{
-                <<"interval">> := 60,
+                <<"interval">> := 60000, % converted to ms
                 <<"path">> := <<"/Users/ferd/images/">>,
                 <<"ignore">> := []
             }


### PR DESCRIPTION
Turns out the config intended to use seconds, and anything internal used milliseconds. I found out about it because it made no sense how much CPU I was burning for an app that should run once an hour in my local deployment.

then I fixed it and found tests failing that worked because they accidentally relied on short delays of 60ms instead of 60s to do an initial scan, so I made `revault_dirmon_event` auto-scan on start to fix it all. This also surfaced a bit I had forgot in that a lot of my property tests rely on a raw scan to work and check the behavior of the tracking, whereas execution works on a re-scan, so I had to do a little bit of juggling to make all use cases happy.

This should all be more robust and energy-efficient now. Also it highlights the need for me to add more telemetry to this code to surface this stuff better.