### PR TITLE
Reduce packet recv instrumentation

### DIFF
--- a/apps/revault/src/revault_tls.hrl
+++ b/apps/revault/src/revault_tls.hrl
@@ -6,7 +6,8 @@
 -define(SERVER, {via, gproc, {n, l, {tls, serv, shared}}}).
 -define(CLIENT(Name), {via, gproc, {n, l, {tls, client, Name}}}).
 -record(client, {name, dirs, peer, dir, auth, opts, sock,
-                 buf = revault_tls:buf_new(), ctx = []}).
+                 recv = false, buf = revault_tls:buf_new(), ctx = []}).
 -record(serv, {names=#{}, dirs, opts, sock, acceptor, workers=#{}}).
--record(conn, {localname, sock, dirs, buf = revault_tls:buf_new(), ctx = []}).
+-record(conn, {localname, sock, dirs,
+               recv = false, buf = revault_tls:buf_new(), ctx = []}).
 


### PR DESCRIPTION
Sending one span per recv calls makes the traces noisy and nearly useless, particularly during large file transfers.

Instead, this patch reduces the number of spans to one per message batch where messages are successfully unpacked. This will allow to create a sort of aggregate value where the number of bytes in the buffer can be compared to the duration of the span to derive transfer rates, and I've also added a trailing value to better track what was received and consumed vs. received and left for the next batch.

This should bring back the traces to a manageable level now that performance woes are mostly taken care of, or at least brought to a reasonable level.