### PR TITLE
Support config reload, client/server mode switch

### DIFF
--- a/apps/maestro/test/session_SUITE_data/others/a_switch.toml
+++ b/apps/maestro/test/session_SUITE_data/others/a_switch.toml
@@ -1,0 +1,29 @@
+[db]
+  path = "./db/a/"
+
+[dirs]
+  [dirs.test]
+  interval = 60
+  path = "./a"
+
+[server]
+    [server.auth.tls]
+    # status = "disabled"
+    port = 8022
+    certfile = "./others/certs/a.crt"
+    keyfile = "./others/certs/a.key"
+    [server.auth.tls.authorized]
+        [server.auth.tls.authorized.b]
+        # each peer should have a unique peer certificate to auth it
+        certfile = "./others/certs/b.crt"
+        sync = ["test"]
+
+[peers]
+  [peers.b]
+  sync = ["test"]
+  url = "127.0.0.1:8023"
+    [peers.b.auth]
+    type = "tls"
+    certfile = "./others/certs/a.crt"
+    keyfile = "./others/certs/a.key"
+    peer_certfile = "./others/certs/b.crt"

--- a/apps/maestro/test/session_SUITE_data/others/b_switch.toml
+++ b/apps/maestro/test/session_SUITE_data/others/b_switch.toml
@@ -1,0 +1,29 @@
+[db]
+  path = "./db/b/"
+
+[dirs]
+  [dirs.test]
+  interval = 60
+  path = "./b"
+
+[peers]
+  [peers.a]
+  sync = ["test"]
+  url = "127.0.0.1:8022"
+    [peers.a.auth]
+    type = "tls"
+    certfile = "./others/certs/b.crt"
+    keyfile = "./others/certs/b.key"
+    peer_certfile = "./others/certs/a.crt"
+
+[server]
+    [server.auth.tls]
+    # status = "disabled"
+    port = 8023
+    certfile = "./others/certs/b.crt"
+    keyfile = "./others/certs/b.key"
+    [server.auth.tls.authorized]
+        [server.auth.tls.authorized.a]
+        # each peer should have a unique peer certificate to auth it
+        certfile = "./others/certs/a.crt"
+        sync = ["test"]

--- a/apps/revault/src/revault_fsm_sup.erl
+++ b/apps/revault/src/revault_fsm_sup.erl
@@ -8,7 +8,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_fsm/4, start_fsm/5]).
+-export([start_link/0, start_fsm/4, start_fsm/5, stop_all/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -27,6 +27,12 @@ start_fsm(DbDir, Name, Path, Interval) ->
 
 start_fsm(DbDir, Name, Path, Interval, Callback) ->
     supervisor:start_child(?SERVER, [DbDir, Name, Path, Interval, Callback]).
+
+stop_all() ->
+    [supervisor:terminate_child(?SERVER, Pid)
+     || {_, Pid, _, _} <- supervisor:which_children(?SERVER),
+        is_pid(Pid)],
+    ok.
 
 %%====================================================================
 %% Supervisor callbacks

--- a/apps/revault/src/revault_protocols_sup.erl
+++ b/apps/revault/src/revault_protocols_sup.erl
@@ -9,7 +9,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, reset/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -22,6 +22,14 @@
 
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+reset() ->
+    %% it is easiest to restart the child to drop their state and all
+    %% their workers, but leave them in place to work fine later since
+    %% they're expected to be around.
+    [supervisor:restart_child(?SERVER, Id)
+     || {Id, _, _, _} <- supervisor:which_children(?SERVER)],
+    ok.
 
 %%====================================================================
 %% Supervisor callbacks

--- a/apps/revault/src/revault_trackers_sup.erl
+++ b/apps/revault/src/revault_trackers_sup.erl
@@ -8,7 +8,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_tracker/5]).
+-export([start_link/0, start_tracker/5, stop_all/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -24,6 +24,12 @@ start_link() ->
 
 start_tracker(Name, Id, Path, Interval, DbDir) ->
     supervisor:start_child(?SERVER, [Name, Id, Path, Interval, DbDir]).
+
+stop_all() ->
+    [supervisor:terminate_child(?SERVER, Pid)
+     || {_, Pid, _, _} <- supervisor:which_children(?SERVER),
+        is_pid(Pid)],
+    ok.
 
 %%====================================================================
 %% Supervisor callbacks

--- a/apps/revault/test/revault_fsm_SUITE.erl
+++ b/apps/revault/test/revault_fsm_SUITE.erl
@@ -189,8 +189,12 @@ start_hierarchy(Config) ->
     ok = revault_fsm:server(Name),
     %% As a server it bootstrapped its own ID
     ?assertNotEqual(undefined, revault_fsm:id(Name)),
-    %% Can't force to switch to client mode now!
-    ?assertEqual({error, busy}, revault_fsm:client(Name)),
+    %% Can force to switch to client mode and back now there's an id!
+    ?assertEqual(ok, revault_fsm:client(Name)),
+    ?assertEqual({error, busy}, revault_fsm:client(Name)), % dupe change
+    ?assertEqual(ok, revault_fsm:server(Name)),
+    ?assertEqual({error, busy}, revault_fsm:server(Name)), % dupe change
+    %% The supervision structure should have been started as part of the setup
     %% The supervision structure should have been started as part of the setup
     ?assert(is_pid(gproc:where({n, l, {revault_fsm, Name}}))),
     ?assert(is_pid(gproc:where({n, l, {revault_tracker_sup, Name}}))),


### PR DESCRIPTION
Support reloading configuration reloading to alter running state of ReVault. This is currently done with a hard stop and restart of all trackers, FSMs, and servers and clients. This is not elegant, but it is sufficient to support simpler tests for mode switch, which is the core feature implemented here.

Mode switching between client and server mode is now supported once the FSM is initialized (an ID and UUID is chosen). The mode switch is handled by going back to initialized mode and handing off the state transition with a postpone.

It will only work if a FSM has both configurations, and the mode switch can be bypassed by straight up calling for a sync or receiving a mode-triggering message (connection, sync) in either the client or server mode, but not while a sync is ongoing.

This will allow to fully support de-centralized topologies where many servers can exist and sync between each other depending on who they talk to.