### PR TITLE
Add fork-seeding operation

### DIFF
--- a/apps/maestro/src/maestro_loader.erl
+++ b/apps/maestro/src/maestro_loader.erl
@@ -149,7 +149,10 @@ start_client(DirName,
             _ = revault_fsm:id(DirName, PeerName),
             ok;
         _ ->
-            ok = revault_fsm:client(DirName)
+            case revault_fsm:client(DirName) of
+                ok -> ok;
+                {error, busy} -> ok
+            end
     end.
 
 start_servers(Cfg = #{<<"server">> := ServMap}) ->


### PR DESCRIPTION
When setting up a new set of replicas, one might start by their local machine, which will initially act as a server. On a local network where all the other peers can see each other, this is fine and easy to deal with as any host is allowed to switch roles between client and server at any point in time.

However, if you're dealing with a VPS (or some other server) or with connections over the Internet, stable IPs and easy reverse DNS might not be around. In such cases, it's possible that a local initial device can't ever be connected to by an Internet-located peer, and that latter device will need to act as a server to work properly.

This causes a clash because we assume that starting in server mode lets you initialize your own ID and UUID state for any given directory.

Since mutual cert pinning over TLS would likely be used for connections over-the-internet and that this assumes a way to transfer public keys for various hosts, I'm also going to assume that there's away for someone to upload a few initial files to bootstrap a remote server.

To support that, this commit adds a fork-seeding operation, where any client or server can be called with a new directory, and be told to fork its ID space and declare the basic state file used for initialization (the ID and UUID files). These files can then be used along with the public keys in setting up the initial state of a remote server, and do the equivalent of an offline ID exchange as allowed by the ReVault protocol.

Support for easier packaging of these files will need to be added in a subsequent commit, probably using the CLI tool for it.