### PR TITLE
Support Ignoring files

### DIFF
--- a/apps/maestro/src/maestro_cfg.erl
+++ b/apps/maestro/src/maestro_cfg.erl
@@ -70,7 +70,7 @@ normalize_dir(Key, Map, Acc) ->
            <<"interval">> => maps:get(<<"interval">>, Map,
                                       ?DEFAULT_INTERVAL_SECONDS)*1000,
            <<"path">> => maps:get(<<"path">>, Map),
-           <<"ignore">> => maps:get(<<"ignore">>, Map, [])
+           <<"ignore">> => maps:get(<<"ignore">>, Map, [<<"\\.DS_Store$">>])
           }
     }.
 

--- a/apps/maestro/src/maestro_loader.erl
+++ b/apps/maestro/src/maestro_loader.erl
@@ -131,6 +131,7 @@ start_client(DirName,
              Cfg=#{<<"db">> := #{<<"path">> := DbDir}, <<"dirs">> := DirsMap},
              PeerName, PeerCfg) ->
     #{DirName := #{<<"interval">> := Interval,
+                   <<"ignore">> := Ignore,
                    <<"path">> := Path}} = DirsMap,
     %% Clients can depend on multiple peers, which can all be valid;
     %% it's possible that only one of the many peers is available at
@@ -139,7 +140,7 @@ start_client(DirName,
     %% existed locally.
     #{<<"auth">> := #{<<"type">> := AuthType}} = PeerCfg,
     Cb = (callback_mod(AuthType)):callback({DirName, Cfg}),
-    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Interval, Cb),
+    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Ignore, Interval, Cb),
     case revault_fsm:id(DirName) of
         undefined ->
             ok = revault_fsm:client(DirName),
@@ -175,9 +176,10 @@ start_server(DirName,
              Cfg=#{<<"db">> := #{<<"path">> := DbDir}, <<"dirs">> := DirsMap},
              Type) ->
     #{DirName := #{<<"interval">> := Interval,
+                   <<"ignore">> := Ignore,
                    <<"path">> := Path}} = DirsMap,
     Cb = (callback_mod(Type)):callback({DirName, Cfg}),
-    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Interval, Cb),
+    _ = revault_fsm_sup:start_fsm(DbDir, DirName, Path, Ignore, Interval, Cb),
     case revault_fsm:id(DirName) of
         undefined ->
             ok = revault_fsm:server(DirName);

--- a/apps/maestro/test/cfg_SUITE.erl
+++ b/apps/maestro/test/cfg_SUITE.erl
@@ -28,12 +28,12 @@ literal(Config) ->
             <<"music">> := #{
                 <<"interval">> := 60000, % converted to ms
                 <<"path">> := <<"~/Music">>,
-                <<"ignore">> := []
+                <<"ignore">> := [<<"\\.DS_Store$">>]
             },
             <<"images">> := #{
                 <<"interval">> := 60000, % converted to ms
                 <<"path">> := <<"/Users/ferd/images/">>,
-                <<"ignore">> := []
+                <<"ignore">> := [<<"\\.DS_Store$">>, <<"\\.exe$">>]
             }
          },
          <<"peers">> := #{

--- a/apps/maestro/test/cfg_SUITE_data/sample.toml
+++ b/apps/maestro/test/cfg_SUITE_data/sample.toml
@@ -9,7 +9,7 @@
   [dirs.images]
   interval = 60
   path = "/Users/ferd/images/"
-  ignore = [] # regexes on full path
+  ignore = ["\\.DS_Store$", "\\.exe$"] # regexes on full path
 
 [peers]
   # VPS copy running

--- a/apps/revault/src/revault_dirmon_tracker.erl
+++ b/apps/revault/src/revault_dirmon_tracker.erl
@@ -5,7 +5,7 @@
 -module(revault_dirmon_tracker).
 -behviour(gen_server).
 -define(VIA_GPROC(Name), {via, gproc, {n, l, {?MODULE, Name}}}).
--export([start_link/4, stop/1, file/2, files/1]).
+-export([start_link/5, stop/1, file/2, files/1]).
 -export([update_id/2, conflict/3, conflict/4, update_file/4, delete_file/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
@@ -26,13 +26,14 @@
                           revault_dirmon_poll:hash() | deleted}
                         }},
     dir :: file:filename_all(),
+    ignore :: revault_dirmon_poll:ignore(),
     storage = undefined :: file:filename_all() | undefined,
     itc_id :: itc:id()
 }).
 
-start_link(Name, Dir, File, VsnSeed) ->
+start_link(Name, Dir, Ignore, File, VsnSeed) ->
     gen_server:start_link(?VIA_GPROC(Name), ?MODULE,
-                          [Name, Dir, VsnSeed, File], []).
+                          [Name, Dir, Ignore, VsnSeed, File], []).
 
 file(Name, File) ->
     gen_server:call(?VIA_GPROC(Name), {file, File}).
@@ -51,7 +52,7 @@ conflict(Name, WorkFile, Vsn = {_Stamp, deleted}) ->
     gen_server:call(?VIA_GPROC(Name), {conflict, WorkFile, Vsn}, infinity).
 
 -spec conflict(term(), file:filename_all(), file:filename_all(),
-               {stamp(), revault_dirmon_poll:hash()}) -> ok.
+               {stamp(), revault_dirmon_poll:hash()}) -> ok | ignored.
 conflict(Name, WorkFile, ConflictFile, Vsn = {_Stamp, _Hash}) ->
     gen_server:call(?VIA_GPROC(Name), {conflict, WorkFile, ConflictFile, Vsn}, infinity).
 
@@ -65,12 +66,13 @@ delete_file(Name, WorkFile, Vsn = {_Stamp, deleted}) ->
 %%% CALLBACKS %%%
 %%%%%%%%%%%%%%%%%
 
-init([Name, Dir, VsnSeed, File]) ->
-    Snapshot = restore_snapshot(File),
+init([Name, Dir, Ignore, VsnSeed, File]) ->
+    Snapshot = restore_snapshot(File, Ignore),
     true = gproc:reg({p, l, Name}),
     {ok, #state{
         snapshot = Snapshot,
         dir = Dir,
+        ignore = Ignore,
         storage = File,
         itc_id = VsnSeed
     }}.
@@ -91,7 +93,11 @@ handle_call({update_id, ITC}, _From, State = #state{}) ->
     save_snapshot(NewState),
     {reply, ok, NewState};
 handle_call({conflict, Work, Conflict, {NewStamp, NewHash}}, _From,
-            State = #state{snapshot=Map, dir=Dir, itc_id=Id}) ->
+            State = #state{snapshot=Map, dir=Dir, ignore=Ignore, itc_id=Id}) ->
+    case processable(Work, Ignore) of
+        false -> throw({reply, ignored, State});
+        true -> ok
+    end,
     NewConflict = case Map of
         #{Work := {Stamp, {conflict, ConflictHashes, WorkingHash}}} ->
             %% A conflict already existed; add to it.
@@ -133,7 +139,11 @@ handle_call({conflict, Work, Conflict, {NewStamp, NewHash}}, _From,
     save_snapshot(NewState),
     {reply, ok, NewState};
 handle_call({conflict, Work, {NewStamp, deleted}}, _From,
-            State = #state{snapshot=Map, dir=Dir, itc_id=Id}) ->
+            State = #state{snapshot=Map, dir=Dir, ignore=Ignore, itc_id=Id}) ->
+    case processable(Work, Ignore) of
+        false -> throw({reply, ignored, State});
+        true -> ok
+    end,
     NewConflict = case Map of
         #{Work := {Stamp, {conflict, ConflictHashes, WorkingHash}}} ->
             %% A conflict already existed; nothing to do with the conflict
@@ -158,7 +168,11 @@ handle_call({conflict, Work, {NewStamp, deleted}}, _From,
     save_snapshot(NewState),
     {reply, ok, NewState};
 handle_call({update_file, Work, Source, {NewStamp, NewHash}}, _From,
-            State = #state{snapshot=Map, dir=Dir, itc_id=Id}) ->
+            State = #state{snapshot=Map, dir=Dir, ignore=Ignore,  itc_id=Id}) ->
+    case processable(Work, Ignore) of
+        false -> throw({reply, ignored, State});
+        true -> ok
+    end,
     case Map of
         #{Work := {Stamp, {conflict, Hashes, _}}} ->
             case compare(Id, Stamp, NewStamp) of
@@ -199,7 +213,11 @@ handle_call({update_file, Work, Source, {NewStamp, NewHash}}, _From,
             {reply, ok, NewState}
     end;
 handle_call({delete_file, Work, {NewStamp, deleted}}, _From,
-            State = #state{snapshot=Map, dir=Dir, itc_id=Id}) ->
+            State = #state{snapshot=Map, dir=Dir, ignore=Ignore, itc_id=Id}) ->
+    case processable(Work, Ignore) of
+        false -> throw({reply, ignored, State});
+        true -> ok
+    end,
     case Map of
         #{Work := {Stamp, {conflict, Hashes, _}}} ->
             case compare(Id, Stamp, NewStamp) of
@@ -321,12 +339,12 @@ apply_operation({changed, {FileName, Hash}}, SetMap, ITC, _Dir) ->
             SetMap
     end.
 
-restore_snapshot(File) ->
+restore_snapshot(File, Ignore) ->
     case file:consult(File) of
         {error, enoent} ->
             #{};
         {ok, [Snapshot]} ->
-            Snapshot
+            apply_ignores(Snapshot, Ignore)
     end.
 
 save_snapshot(#state{storage = undefined}) ->
@@ -405,3 +423,11 @@ resolve_conflict(Dir, BaseFile, Hashes) ->
      )) || ConflictHash <- Hashes],
     ok.
 
+%% @private the Ignore set can change across various runs. We can apply
+%% the ignore set on the snapshot to prune the files that are no longer
+%% desired in it.
+apply_ignores(Snapshot, Ignore) ->
+    maps:filter(fun(K,_) -> processable(K, Ignore) end, Snapshot).
+
+processable(FileName, Ignore) ->
+    revault_dirmon_poll:processable(FileName, Ignore).

--- a/apps/revault/src/revault_dirmon_tracker.erl
+++ b/apps/revault/src/revault_dirmon_tracker.erl
@@ -47,7 +47,7 @@ stop(Name) ->
 update_id(Name, Id) ->
     gen_server:call(?VIA_GPROC(Name), {update_id, Id}, infinity).
 
--spec conflict(term(), file:filename_all(), {stamp(), deleted}) -> ok.
+-spec conflict(term(), file:filename_all(), {stamp(), deleted}) -> ok | ignored.
 conflict(Name, WorkFile, Vsn = {_Stamp, deleted}) ->
     gen_server:call(?VIA_GPROC(Name), {conflict, WorkFile, Vsn}, infinity).
 

--- a/apps/revault/src/revault_fsm_sup.erl
+++ b/apps/revault/src/revault_fsm_sup.erl
@@ -8,7 +8,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_fsm/4, start_fsm/5, stop_all/0]).
+-export([start_link/0, start_fsm/5, start_fsm/6, stop_all/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -22,11 +22,11 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-start_fsm(DbDir, Name, Path, Interval) ->
-    supervisor:start_child(?SERVER, [DbDir, Name, Path, Interval]).
+start_fsm(DbDir, Name, Path, Ignore, Interval) ->
+    supervisor:start_child(?SERVER, [DbDir, Name, Path, Ignore, Interval]).
 
-start_fsm(DbDir, Name, Path, Interval, Callback) ->
-    supervisor:start_child(?SERVER, [DbDir, Name, Path, Interval, Callback]).
+start_fsm(DbDir, Name, Path, Ignore, Interval, Callback) ->
+    supervisor:start_child(?SERVER, [DbDir, Name, Path, Ignore, Interval, Callback]).
 
 stop_all() ->
     [supervisor:terminate_child(?SERVER, Pid)

--- a/apps/revault/src/revault_trackers_sup.erl
+++ b/apps/revault/src/revault_trackers_sup.erl
@@ -8,7 +8,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_tracker/5, stop_all/0]).
+-export([start_link/0, start_tracker/6, stop_all/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -22,8 +22,8 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-start_tracker(Name, Id, Path, Interval, DbDir) ->
-    supervisor:start_child(?SERVER, [Name, Id, Path, Interval, DbDir]).
+start_tracker(Name, Id, Path, Ignore, Interval, DbDir) ->
+    supervisor:start_child(?SERVER, [Name, Id, Path, Ignore, Interval, DbDir]).
 
 stop_all() ->
     [supervisor:terminate_child(?SERVER, Pid)

--- a/apps/revault/test/dirmon_event_SUITE.erl
+++ b/apps/revault/test/dirmon_event_SUITE.erl
@@ -27,7 +27,7 @@ scan_with_timeouts(Config) ->
     {ok, _} = revault_dirmon_event:start_link(
       {?MODULE, ?FUNCTION_NAME},
       #{directory => PrivDir, poll_interval => 10,
-        initial_sync => scan}
+        ignore => [], initial_sync => scan}
     ),
     ok = file:write_file(AbsFile, "text"),
     H0 = receive
@@ -58,7 +58,7 @@ survive_unexpected_msgs(Config) ->
     {ok, Pid} = revault_dirmon_event:start_link(
       {?MODULE, ?FUNCTION_NAME},
       #{directory => PrivDir, poll_interval => 1000000,
-        initial_sync => scan}
+        ignore => [], initial_sync => scan}
     ),
     Pid ! make_ref(),
     gen_server:cast(Pid, make_ref()),

--- a/apps/revault/test/dirmon_tracker_SUITE.erl
+++ b/apps/revault/test/dirmon_tracker_SUITE.erl
@@ -51,6 +51,7 @@ init_per_testcase(Name, Config) ->
     {ok, Tracker} = revault_dirmon_tracker:start_link(
         Name,
         FilesDir,
+        [],
         filename:join([StoreDir, "snapshot"]),
         revault_id:new()
     ),
@@ -58,6 +59,7 @@ init_per_testcase(Name, Config) ->
         Name,
         #{directory => FilesDir,
           initial_sync => tracker,
+          ignore => [],
           poll_interval => 6000000} % too long to interfere
     ),
     [{name, Name}, {tracker, Tracker}, {event, Event}, {apps, Apps},

--- a/apps/revault/test/dirmon_tracker_SUITE.erl
+++ b/apps/revault/test/dirmon_tracker_SUITE.erl
@@ -7,7 +7,8 @@ all() ->
     [{group, update},
      {group, delete},
      conflict_creation,
-     {group, conflict_resolution}].
+     {group, conflict_resolution},
+     {group, ignores}].
 
 groups() ->
     [{conflict_resolution, [], [
@@ -31,6 +32,10 @@ groups() ->
         delete_conflict,
         delete_conflict_resolve,
         delete_conflict_older
+     ]},
+     {ignores, [], [
+        ignore_older,
+        ignore_incoming
      ]}
     ].
 
@@ -40,11 +45,38 @@ groups() ->
     %%       from the tracked file
     %% TODO: weird ass things like moving conflicting files around
 
+init_per_testcase(ignore_incoming, Config) ->
+    Name = ?config(name, Config),
+    {ok, Apps} = application:ensure_all_started(gproc),
+    FilesDir = filename:join([?config(priv_dir, Config), "files"]),
+    StoreDir = filename:join([?config(priv_dir, Config), "store"]),
+    TmpDir = filename:join([?config(priv_dir, Config), "tmp"]),
+    ID = revault_id:new(),
+    ok = filelib:ensure_dir(filename:join([FilesDir, ".touch"])),
+    ok = filelib:ensure_dir(filename:join([StoreDir, ".touch"])),
+    ok = filelib:ensure_dir(filename:join([TmpDir, ".touch"])),
+    {ok, Tracker} = revault_dirmon_tracker:start_link(
+        Name,
+        FilesDir,
+        ["ignorable"],
+        filename:join([StoreDir, "snapshot"]),
+        ID
+    ),
+    {ok, Event} = revault_dirmon_event:start_link(
+        Name,
+        #{directory => FilesDir,
+          initial_sync => tracker,
+          ignore => ["ignorable"],
+          poll_interval => 6000000} % too long to interfere
+    ),
+    [{name, Name}, {id, ID}, {tracker, Tracker}, {event, Event}, {apps, Apps},
+     {files_dir, FilesDir}, {tmp_dir, TmpDir}, {store_dir, StoreDir} | Config];
 init_per_testcase(Name, Config) ->
     {ok, Apps} = application:ensure_all_started(gproc),
     FilesDir = filename:join([?config(priv_dir, Config), "files"]),
     StoreDir = filename:join([?config(priv_dir, Config), "store"]),
     TmpDir = filename:join([?config(priv_dir, Config), "tmp"]),
+    ID = revault_id:new(),
     ok = filelib:ensure_dir(filename:join([FilesDir, ".touch"])),
     ok = filelib:ensure_dir(filename:join([StoreDir, ".touch"])),
     ok = filelib:ensure_dir(filename:join([TmpDir, ".touch"])),
@@ -53,7 +85,7 @@ init_per_testcase(Name, Config) ->
         FilesDir,
         [],
         filename:join([StoreDir, "snapshot"]),
-        revault_id:new()
+        ID
     ),
     {ok, Event} = revault_dirmon_event:start_link(
         Name,
@@ -62,12 +94,12 @@ init_per_testcase(Name, Config) ->
           ignore => [],
           poll_interval => 6000000} % too long to interfere
     ),
-    [{name, Name}, {tracker, Tracker}, {event, Event}, {apps, Apps},
+    [{name, Name}, {id, ID}, {tracker, Tracker}, {event, Event}, {apps, Apps},
      {files_dir, FilesDir}, {tmp_dir, TmpDir}, {store_dir, StoreDir} | Config].
 
 end_per_testcase(_, Config) ->
-    gen_server:stop(?config(event, Config)),
-    gen_server:stop(?config(tracker, Config)),
+    catch gen_server:stop(?config(event, Config)),
+    catch gen_server:stop(?config(tracker, Config)),
     [application:stop(App) || App <- lists:reverse(?config(apps, Config))],
     Config.
 
@@ -689,6 +721,51 @@ delete_conflict_older(Config) ->
     ?assertMatch({ok, _}, file:read_file(AbsConflictMarker)),
     ?assertMatch({error, enoent}, file:read_file(AbsConflictA)), % created on opposed end sync
     ?assertMatch({ok, _}, file:read_file(AbsConflictB)),
+    ok.
+
+ignore_older() ->
+    [{doc, "Ignoring a file that was previously not ignores prunes it "
+           "from the tracker at start time."}].
+ignore_older(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(files_dir, Config),
+    StoreDir = ?config(store_dir, Config),
+    FilesDir = ?config(files_dir, Config),
+    ID = ?config(id, Config),
+    WorkFile = "ignorable",
+    AbsWorkFile = filename:join([Dir, WorkFile]),
+    ok = file:write_file(AbsWorkFile, <<"a">>),
+    ok = revault_dirmon_event:force_scan(Name, 5000),
+    ?assertMatch(#{WorkFile := _}, revault_dirmon_tracker:files(Name)),
+    gen_server:stop(?config(tracker, Config)),
+    {ok, NewTracker} = revault_dirmon_tracker:start_link(
+        Name,
+        FilesDir,
+        ["ignorable"],
+        filename:join([StoreDir, "snapshot"]),
+        ID
+    ),
+    ?assertNotMatch(#{WorkFile := _}, revault_dirmon_tracker:files(Name)),
+    gen_server:stop(NewTracker),
+    ok.
+
+ignore_incoming() ->
+    [{doc, "Ignoring a file prevents it from being tracked."}].
+ignore_incoming(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(files_dir, Config),
+    TmpFile = filename:join([?config(tmp_dir, Config), "ignorable"]),
+    WorkFile = "ignorable",
+    AbsWorkFile = filename:join([Dir, WorkFile]),
+    FakeMeta = {1, <<"hash">>},
+    DelMeta = {1, deleted},
+    ok = file:write_file(AbsWorkFile, <<"a">>),
+    ok = revault_dirmon_event:force_scan(Name, 5000),
+    ?assertNotMatch(#{WorkFile := _}, revault_dirmon_tracker:files(Name)),
+    ?assertEqual(ignored, revault_dirmon_tracker:conflict(Name, WorkFile, AbsWorkFile, FakeMeta)),
+    ?assertEqual(ignored, revault_dirmon_tracker:conflict(Name, WorkFile, DelMeta)),
+    ?assertEqual(ignored, revault_dirmon_tracker:update_file(Name, WorkFile, TmpFile, FakeMeta)),
+    ?assertEqual(ignored, revault_dirmon_tracker:delete_file(Name, WorkFile, DelMeta)),
     ok.
 
 %%%%%%%%%%%%%%%

--- a/apps/revault/test/prop_dirmon_event_statem.erl
+++ b/apps/revault/test/prop_dirmon_event_statem.erl
@@ -31,6 +31,7 @@ prop_test() ->
                     ?LISTENER_NAME,
                     #{directory => ?DIR,
                       initial_sync => scan,
+                      ignore => [],
                       poll_interval => 6000000} % too long to interfere
                 ),
                 Listener = spawn_link(fun listener/0),

--- a/apps/revault/test/prop_dirmon_poll_statem.erl
+++ b/apps/revault/test/prop_dirmon_poll_statem.erl
@@ -40,7 +40,7 @@ initial_state() ->
 command(#{model := T, set := Set}) ->
     Calls = [
         ?LAZY(dirmodel:file_add(?DIR, T)),
-        {call, revault_dirmon_poll, rescan, [?DIR, Set]}
+        {call, revault_dirmon_poll, rescan, [?DIR, [], Set]}
     ]
     ++ case dirmodel:has_files(T) of
         false ->
@@ -77,7 +77,7 @@ postcondition(_State, {call, _, change_file, _}, ok) ->
     true;
 postcondition(_State, {call, _, delete_file, _}, ok) ->
     true;
-postcondition(State, {call, _, rescan, [_, _]}, Ret) ->
+postcondition(State, {call, _, rescan, [_, _, _]}, Ret) ->
     {ExpDel, ExpAdd, ExpMod} = merge_ops(
         [{Op, {F,C}} || {Op, {F,C}} <- maps:get(ops, State)],
         maps:get(snapshot, State)

--- a/apps/revault/test/prop_dirmon_tracker.erl
+++ b/apps/revault/test/prop_dirmon_tracker.erl
@@ -3,6 +3,7 @@
 -define(DIR, "_build/test/scratch").
 -define(STORE, "_build/test/scratchstore").
 -define(LISTENER_NAME, {?MODULE, ?DIR}).
+-define(IGNORE, []).
 -define(ITC_SEED, element(1, itc:explode(itc:seed()))).
 -compile(export_all).
 
@@ -34,6 +35,7 @@ prop_test() ->
                 {ok, _Listener} = revault_dirmon_tracker:start_link(
                     ?LISTENER_NAME,
                     ?DIR,
+                    ?IGNORE,
                     ?STORE,
                     ?ITC_SEED
                 ),
@@ -41,6 +43,7 @@ prop_test() ->
                     ?LISTENER_NAME,
                     #{directory => ?DIR,
                       initial_sync => tracker_manual,
+                      ignore => [],
                       poll_interval => 6000000} % too long to interfere
                 ),
                 {History, State, Result} = run_commands(?MODULE, Cmds),
@@ -73,6 +76,7 @@ prop_monotonic() ->
             {ok, Listener} = revault_dirmon_tracker:start_link(
                 ?LISTENER_NAME,
                 ?DIR,
+                ?IGNORE,
                 undefined,
                 Id
             ),
@@ -235,7 +239,7 @@ file_deleted(File, Dir, Model, Ops) ->
 
 restart_tracker() ->
     revault_dirmon_tracker:stop(?LISTENER_NAME),
-    revault_dirmon_tracker:start_link(?LISTENER_NAME, ?DIR, ?STORE, ?ITC_SEED).
+    revault_dirmon_tracker:start_link(?LISTENER_NAME, ?DIR, ?IGNORE, ?STORE, ?ITC_SEED).
 
 restart_event() ->
     revault_dirmon_event:stop(?LISTENER_NAME),
@@ -243,6 +247,7 @@ restart_event() ->
         ?LISTENER_NAME,
         #{directory => ?DIR,
           initial_sync => tracker_manual,
+          ignore => ?IGNORE,
           poll_interval => 6000000} % too long to interfere
     ).
 


### PR DESCRIPTION
This is a lot more tedious work than I thought, because this is weaving
the list of regexes through a lot more stuff than expected -- mostly the
dirmon tracker and the dirmon poll processes that need it directly,
but since these are part of a whole instantiation hierarchy
starting with maestro and going through the FSM, well here we are.

The default ignore list now includes .DS_Store files. Tests demonstrate
support of the new change (and of how it can migrate away from
an old ignore list via the tracker filtering out its snapshot on load).

