### PR TITLE
Implement a disk-based hash cache

### DIFF
--- a/apps/maestro/test/session_SUITE.erl
+++ b/apps/maestro/test/session_SUITE.erl
@@ -9,12 +9,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
-all() -> [{group, default}, {group, with_hash_cache}].
-
-groups() -> [{default, [], [{group, sessions}]},
-             {with_hash_cache, [], [{group, sessions}]},
-             {sessions, [], [setup_works, copy_and_sync,
-                             conflict_and_sync, role_switch]}].
+all() -> [setup_works, copy_and_sync, conflict_and_sync,
+          role_switch].
 
 %% These values are hardcoded in the toml config files in the suite's
 %% data_dir; changing them here requires changing them there too.
@@ -24,16 +20,6 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(Config) ->
-    Config.
-
-init_per_group(with_hash_cache, Config) ->
-    %% Since the last modified stamps require 1 second
-    %% to go by, scans won't be effective without a pause.
-    [{sync_pause, 1000} | Config];
-init_per_group(_, Config) ->
-    [{sync_pause, 0} | Config].
-
-end_per_group(Config) ->
     Config.
 
 init_per_testcase(set_up_files, Config) ->
@@ -69,12 +55,6 @@ init_per_testcase(set_up_peers, ConfigTmp) ->
     }),
     ok = rpc:call(NodeA, file, set_cwd, [?config(priv_dir, Config)]),
     ok = rpc:call(NodeB, file, set_cwd, [?config(priv_dir, Config)]),
-    %% Set up config for cache
-    Priv = ?config(priv_dir, Config),
-    ok = rpc:call(NodeA, application, set_env, [revault, disk_hash_cache, true]),
-    ok = rpc:call(NodeA, application, set_env, [revault, disk_hash_cache_path, Priv]),
-    ok = rpc:call(NodeB, application, set_env, [revault, disk_hash_cache, true]),
-    ok = rpc:call(NodeB, application, set_env, [revault, disk_hash_cache_path, Priv]),
     [{peer_a, {PidA, NodeA}}, {peer_b, {PidB, NodeB}} | Config];
 init_per_testcase(_, ConfigTmp) ->
     Config = init_per_testcase(set_up_peers, ConfigTmp),
@@ -100,9 +80,7 @@ init_per_testcase(_, ConfigTmp) ->
 end_per_testcase(_, Config) ->
     {PidA, _NodeA} = ?config(peer_a, Config),
     {PidB, _NodeB} = ?config(peer_b, Config),
-    ct:pal("Stopping Peer A"),
     peer:stop(PidA),
-    ct:pal("Stopping Peer B"),
     peer:stop(PidB),
     Config.
 
@@ -134,7 +112,6 @@ copy_and_sync(Config) ->
     ?assertEqual(ok, rpc:call(ClientNode, revault_fsm, sync, [Dir, ServerName])),
     ?assertEqual(tree(DirA), tree(DirB)),
     %% initial sync, now deal with some writes.
-    timer:sleep(?config(sync_pause, Config)),
     copy(filename:join(?config(data_dir, Config), "b"), DirB),
     ?assertNotEqual(tree(DirA), tree(DirB)),
     ok = rpc:call(ClientNode, revault_dirmon_event, force_scan, [Dir, infinity]),
@@ -162,14 +139,12 @@ conflict_and_sync(Config) ->
     %% resolves all conflicts to the server as the superset.
     ?assertEqual(ok, rpc:call(ClientNode, revault_fsm, sync, [Dir, ServerName])),
     %% Now we can copy files and declare some conflicts.
-    timer:sleep(?config(sync_pause, Config)),
     copy(filename:join(?config(data_dir, Config), "b"), DirB),
     file:write_file(filename:join(DirA, "shared.txt"), <<"ccc\n">>),
     ?assertNotEqual(tree(DirA), tree(DirB)),
     ok = rpc:call(ClientNode, revault_dirmon_event, force_scan, [Dir, infinity]),
     ok = rpc:call(ServerNode, revault_dirmon_event, force_scan, [Dir, infinity]),
     %% Now we should sync and get conflict files
-    timer:sleep(?config(sync_pause, Config)),
     ?assertEqual(ok, rpc:call(ClientNode, revault_fsm, sync, [Dir, ServerName])),
     TreeA = tree(DirA),
     TreeB = tree(DirB),
@@ -224,7 +199,6 @@ role_switch(Config) ->
     wait_until(fun() -> current == rpc:call(ServerNode, maestro_loader, status, []) end),
     wait_until(fun() -> current == rpc:call(ClientNode, maestro_loader, status, []) end),
     %% now deal with some writes.
-    timer:sleep(?config(sync_pause, Config)),
     copy(filename:join(?config(data_dir, Config), "b"), DirB),
     ?assertNotEqual(tree(DirA), tree(DirB)),
     ok = rpc:call(ClientNode, revault_dirmon_event, force_scan, [Dir, infinity]),

--- a/apps/maestro/test/session_SUITE_data/b/shared.txt
+++ b/apps/maestro/test/session_SUITE_data/b/shared.txt
@@ -1,1 +1,1 @@
-bbb
+bbbb

--- a/apps/revault/src/revault_backend_sup.erl
+++ b/apps/revault/src/revault_backend_sup.erl
@@ -9,7 +9,7 @@
 
 %% API
 -export([start_link/0,
-         start_disk_subtree/0, start_s3_subtree/5,
+         start_disk_subtree/1, start_s3_subtree/5,
          stop_all/0]).
 
 %% Supervisor callbacks
@@ -24,7 +24,13 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-start_disk_subtree() ->
+start_disk_subtree(DirPath) ->
+    %% TODO: test, particularly the multi-start paths
+    supervisor:start_child(?SERVER, #{
+        id => {disk_cache, DirPath},
+        start => {revault_disk_cache, start_link, [DirPath]},
+        type => worker
+    }),
     application:set_env(revault, backend, disk),
     ok.
 

--- a/apps/revault/src/revault_file_disk.erl
+++ b/apps/revault/src/revault_file_disk.erl
@@ -114,13 +114,13 @@ find_hashes_cached(Dir, Pred) ->
                  Acc;
              true ->
                  RelFile = revault_file:make_relative(Dir, File),
-                 LastModified = filelib:last_modified(File),
+                 CacheInfo = cache_info(File),
                  case revault_disk_cache:hash(Dir, RelFile) of
-                     {ok, {Hash, LastModified}} ->
+                     {ok, {Hash, CacheInfo}} ->
                          [{RelFile, Hash} | Acc];
                      _R ->
                          Hash = hash(File),
-                         revault_disk_cache:hash_store(Dir, RelFile, {Hash, LastModified}),
+                         revault_disk_cache:hash_store(Dir, RelFile, {Hash, CacheInfo}),
                          [{RelFile, Hash} | Acc]
                  end
          end
@@ -302,3 +302,7 @@ hash_fd(Fd, Offset, Size, Threshold, HashState) when Offset < Size ->
     {ok, Bin} = file:pread(Fd, Offset, Bytes),
     hash_fd(Fd, Offset+Bytes, Size, Threshold,
             crypto:hash_update(HashState, Bin)).
+
+cache_info(Path) ->
+    {ok, Rec} = file:read_file_info(Path, [raw]),
+    Rec#file_info{atime=undefined}.

--- a/apps/revault/src/revault_s3_cache.erl
+++ b/apps/revault/src/revault_s3_cache.erl
@@ -44,7 +44,8 @@ flush(Name) ->
 %%% CALLBACKS %%%
 %%%%%%%%%%%%%%%%%
 init({DbDir, Name}) ->
-    CacheFile = filename:join([DbDir, Name]),
+    SplitName = filename:split(Name) -- ["/", <<"/">>],
+    CacheFile = filename:join([DbDir | SplitName]),
     {ok, #state{cache_file=CacheFile, name=Name}}.
 
 handle_call(load, _From, S=#state{name=Name, cache_file=CacheFile}) ->

--- a/apps/revault/test/revault_file_disk_SUITE.erl
+++ b/apps/revault/test/revault_file_disk_SUITE.erl
@@ -5,7 +5,50 @@
 
 all() ->
     [read_range, multipart, multipart_hash,
-     hash_large_file].
+     hash_large_file, hash_cache, cache_check].
+
+init_per_testcase(hash_cache, Config) ->
+    CachePath = application:get_env(revault, disk_hash_cache_path),
+    Priv = ?config(priv_dir, Config),
+    application:set_env(revault, disk_hash_cache_path, filename:join(Priv, "hash_cache")),
+    {ok, Apps} = application:ensure_all_started(gproc),
+    {ok, Pid} = revault_disk_cache:start_link(hash_cache_test),
+    [{serv, Pid}, {apps, Apps},
+     {appenv, [{revault, disk_hash_cache_path, CachePath}]} | Config];
+init_per_testcase(cache_check, Config) ->
+    Cache = application:get_env(revault, disk_hash_cache),
+    CachePath = application:get_env(revault, disk_hash_cache_path),
+    Priv = ?config(priv_dir, Config),
+    Dir = filename:join(Priv, "files"),
+    application:set_env(revault, disk_hash_cache_path, filename:join(Priv, "hash_cache")),
+    {ok, Apps} = application:ensure_all_started(gproc),
+    {ok, Pid} = revault_disk_cache:start_link(Dir),
+    [{serv, Pid}, {apps, Apps}, {dir, Dir},
+     {appenv, [{revault, disk_hash_cache, Cache},
+               {revault, disk_hash_cache_path, CachePath}]} | Config];
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, Config) ->
+    catch meck:unload(revault_file_disk),
+    case ?config(serv, Config) of
+        undefined -> ok;
+        Pid -> gen_server:stop(Pid)
+    end,
+    case ?config(apps, Config) of
+        undefined -> ok;
+        Apps -> [application:stop(App) || App <- lists:reverse(Apps)]
+    end,
+    case ?config(appenv, Config) of
+        undefined ->
+            ok;
+        Vals ->
+            [case Val of
+                 {A, K, undefined} -> application:unset_env(A, K);
+                 {A, K, {ok, V}} -> application:set_env(A, K, V)
+             end || Val <- Vals]
+    end,
+    Config.
 
 read_range() ->
     [{doc, "general checks on reading subsets of files"}].
@@ -76,7 +119,7 @@ hash_large_file() ->
 hash_large_file(Config) ->
     WidthBytes = 100,
     WidthBits = 8*WidthBytes,
-    Parts = 11,
+    _Parts = 11,
     Bin = <<0:WidthBits, 1:WidthBits, 2:WidthBits, 3:WidthBits, 4:WidthBits,
             5:WidthBits, 6:WidthBits, 7:WidthBits, 8:WidthBits, 9:WidthBits, 10>>,
     File = filename:join([?config(priv_dir, Config), "multipart.scratch"]),
@@ -92,3 +135,49 @@ hash_large_file(Config) ->
     end,
     ?assertEqual(HashDisk, Hash),
     ok.
+
+hash_cache() ->
+    [{doc, "try hash cache operations, with mocked calls."}].
+hash_cache(_Config) ->
+    Dir = hash_cache_test,
+    ?assertEqual(ok, revault_disk_cache:flush(Dir)),
+    ?assertEqual(ok, revault_disk_cache:ensure_loaded(Dir)),
+    ?assertEqual(undefined, revault_disk_cache:hash(Dir, <<"key">>)),
+    ?assertEqual(ok, revault_disk_cache:hash_store(Dir, <<"key">>,
+                                                 {<<"val">>, <<"stamp">>})),
+    ?assertEqual({ok, {<<"val">>, <<"stamp">>}},
+                 revault_disk_cache:hash(Dir, <<"key">>)),
+    ?assertEqual(ok, revault_disk_cache:save(Dir)),
+    ?assertEqual({ok, {<<"val">>, <<"stamp">>}},
+                 revault_disk_cache:hash(Dir, <<"key">>)),
+    meck:expect(revault_file_disk, consult,
+                fun(_) -> {ok, [{Dir, #{<<"key">> => <<"?">>}}]} end),
+    ?assertEqual(ok, revault_disk_cache:ensure_loaded(Dir)),
+    ?assertEqual({ok, <<"?">>},
+                 revault_disk_cache:hash(Dir, <<"key">>)),
+    ok.
+
+cache_check() ->
+    [{doc, "Check the behavior of cached hashes matches the uncached one."}].
+cache_check(Config) ->
+    Dir = ?config(dir, Config),
+    ?assertEqual(ok, revault_disk_cache:flush(Dir)),
+    ?assertEqual(ok, revault_disk_cache:ensure_loaded(Dir)),
+    application:set_env(revault, disk_hash_cache, true),
+    file:write_file(filename:join(Dir, "a"), <<"a1">>),
+    file:write_file(filename:join(Dir, "b"), <<"b1">>),
+    file:write_file(filename:join(Dir, "c"), <<"c1">>),
+    Cache1 = revault_file_disk:find_hashes(Dir, fun(_) -> true end),
+    application:set_env(revault, disk_hash_cache, false),
+    NoCache1 = revault_file_disk:find_hashes(Dir, fun(_) -> true end),
+    ?assertEqual(Cache1, NoCache1),
+    timer:sleep(1000), % bump the seconds
+    application:set_env(revault, disk_hash_cache, true),
+    file:write_file(filename:join(Dir, "a"), <<"a2">>),
+    file:write_file(filename:join(Dir, "b"), <<"b2">>),
+    Cache2 = revault_file_disk:find_hashes(Dir, fun(_) -> true end),
+    application:set_env(revault, disk_hash_cache, false),
+    NoCache2 = revault_file_disk:find_hashes(Dir, fun(_) -> true end),
+    ?assertEqual(Cache2, NoCache2),
+    ok.
+

--- a/config/sys.config
+++ b/config/sys.config
@@ -2,8 +2,8 @@
   {revault, [
     {s3_tmpdir, ".tmp"},
     %% Turn this on at your own risk, some updates
-    %% may be missed since last modified stamps are
-    %% not very granular at the second level.
+    %% may be missed since this cache uses a mix of modification
+    %% times and file sizes to avoid re-hashing files.
     {disk_hash_cache, false}
   ]},
   {maestro, []},

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,6 +1,7 @@
 [
   {revault, [
-    {s3_tmpdir, ".tmp"}
+    {s3_tmpdir, ".tmp"},
+    {disk_hash_cache, false}
   ]},
   {maestro, []},
   {opentelemetry,

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,6 +1,9 @@
 [
   {revault, [
     {s3_tmpdir, ".tmp"},
+    %% Turn this on at your own risk, some updates
+    %% may be missed since last modified stamps are
+    %% not very granular at the second level.
     {disk_hash_cache, false}
   ]},
   {maestro, []},

--- a/config/tests.sys.config
+++ b/config/tests.sys.config
@@ -1,6 +1,7 @@
 [
   {revault, [
-    {s3_tmpdir, ".tmp"}
+    {s3_tmpdir, ".tmp"},
+    {disk_hash_cache, false}
   ]},
   {maestro, []},
   {opentelemetry,


### PR DESCRIPTION
Inspired by the S3 hash cache and the slow runtimes on my bad VPS for some file synchronization where scanning a moderate size directory for hashes could take 20-30 seconds on unchanged data, this PR implements an optional hash cache for disk backends.

I initially started only using last-modified times (as in the first commits), but this showed a consistent failure in synchronization tests, which run too fast to detect sub-second edit times. However, I know that S3 usage works, and I also understand that logically the cache _should_ work, and the problem is mostly granularity at test level.

So instead the cache uses overall file info details, which includes modification and change times, but also inode and file size (we ignore access time because reading shouldn't be significant). The session tests validating the cache also got their sample file sizes modified to exercise that part of the flow, and now they pass.

In practice, running the `scan` operation on my bad VPS improves drastically:

```
# hydrate the cache on the first run ever:
→ time ./_build/prod/bin/revault_cli scan -dirs books
Scanning books: ok
./_build/prod/bin/revault_cli scan -dirs books  0.50s user 0.18s system 2% cpu 24.197 total

# run with a hot cache
→ time ./_build/prod/bin/revault_cli scan -dirs books
Scanning books: ok
./_build/prod/bin/revault_cli scan -dirs books  0.47s user 0.13s system 68% cpu 0.870 total
```

A ~25x improvement on slower disks/file systems seems worth it as an option, particularly when one wants to synchronize much bigger files.