### PR TITLE
Major bug fixing for s3 file listing

### DIFF
--- a/apps/revault/src/revault_dirmon_event.erl
+++ b/apps/revault/src/revault_dirmon_event.erl
@@ -89,6 +89,9 @@ initial_sync(tracker_manual, Name, _Dir, _Ignore, _Time) ->
     %% Send in a fake ref, which prevents any timer from ever running
     {Set, make_ref()};
 initial_sync(tracker, Name, _Dir, _Ignore, _Time) ->
+    %% Fake a message to rescan asap on start
+    Ref = make_ref(),
+    self() ! {timeout, Ref, poll},
     %% Normal stateful mode, where we load files and scan ASAP to avoid
     %% getting into modes where long delays mean we are unresponsive
     %% to filesystem changes long after boot.
@@ -97,7 +100,4 @@ initial_sync(tracker, Name, _Dir, _Ignore, _Time) ->
                                       %% ignore deletes from the history, they wouldn't
                                       %% come up in a file scan
                                       Hash =/= deleted]),
-    %% Fake a message to rescan asap on start
-    Ref = make_ref(),
-    self() ! {timeout, Ref, poll},
     {Set, Ref}.

--- a/apps/revault/src/revault_s3.erl
+++ b/apps/revault/src/revault_s3.erl
@@ -381,7 +381,7 @@ list_all_files(Dir, Continuation) ->
     Res = aws_s3:list_objects_v2(client(), bucket(),
                                  BaseOpts#{<<"prefix">> => <<Dir/binary, "/">>}, #{}),
     case Res of
-        {ok, Map=#{<<"ListBucketResult">> := #{<<"Contents">> := Contents}}, _} ->
+        {ok, #{<<"ListBucketResult">> := Map=#{<<"Contents">> := Contents}}, _} ->
             Files = if is_list(Contents) ->
                            [fetch_content(C) || C <- Contents, is_valid_content(C)];
                        is_map(Contents) ->

--- a/apps/revault/test/revault_s3_SUITE.erl
+++ b/apps/revault/test/revault_s3_SUITE.erl
@@ -513,6 +513,19 @@ expect_consult(Bin) ->
 expect_list_objects_v2() ->
     meck:expect(aws_s3, list_objects_v2,
                 fun(_Cli, _Bucket, M=#{<<"prefix">> := _}, _) when not is_map_key(<<"continuation-token">>, M) ->
+                    %% start with a fake subdirectory, as if the server was created
+                    %% by hand.
+                    {ok,
+                     #{<<"ListBucketResult">> =>
+                       #{<<"KeyCount">> => <<"1">>,
+                         <<"Contents">> => [
+                            #{<<"Key">> => <<"dir/">>, <<"LastModified">> => <<"123">>}
+                        ]},
+                       <<"IsTruncated">> => <<"true">>,
+                       <<"NextContinuationToken">> => <<"0">>},
+                     {200, [], make_ref()}};
+                   (_Cli, _Bucket, #{<<"prefix">> := _,
+                                     <<"continuation-token">> := <<"0">>}, _) ->
                     {ok,
                      #{<<"ListBucketResult">> =>
                        #{<<"KeyCount">> => <<"1">>,

--- a/apps/revault/test/revault_s3_SUITE.erl
+++ b/apps/revault/test/revault_s3_SUITE.erl
@@ -518,44 +518,44 @@ expect_list_objects_v2() ->
                     {ok,
                      #{<<"ListBucketResult">> =>
                        #{<<"KeyCount">> => <<"1">>,
+                         <<"IsTruncated">> => <<"true">>,
+                         <<"NextContinuationToken">> => <<"0">>,
                          <<"Contents">> => [
                             #{<<"Key">> => <<"dir/">>, <<"LastModified">> => <<"123">>}
-                        ]},
-                       <<"IsTruncated">> => <<"true">>,
-                       <<"NextContinuationToken">> => <<"0">>},
+                        ]}},
                      {200, [], make_ref()}};
                    (_Cli, _Bucket, #{<<"prefix">> := _,
                                      <<"continuation-token">> := <<"0">>}, _) ->
                     {ok,
                      #{<<"ListBucketResult">> =>
                        #{<<"KeyCount">> => <<"1">>,
+                         <<"IsTruncated">> => <<"true">>,
+                         <<"NextContinuationToken">> => <<"a">>,
                          <<"Contents">> => [
                             #{<<"Key">> => <<"dir/a">>, <<"LastModified">> => <<"123">>}
-                        ]},
-                       <<"IsTruncated">> => <<"true">>,
-                       <<"NextContinuationToken">> => <<"a">>},
+                        ]}},
                      {200, [], make_ref()}};
                    (_Cli, _Bucket, #{<<"prefix">> := _,
                                      <<"continuation-token">> := <<"a">>}, _) ->
                     {ok,
                      #{<<"ListBucketResult">> =>
                        #{<<"KeyCount">> => <<"1">>,
+                         <<"IsTruncated">> => <<"true">>,
+                         <<"NextContinuationToken">> => <<"b">>,
                          <<"Contents">> => #{<<"Key">> => <<"dir/b">>,
-                                             <<"LastModified">> => <<"123">>}},
-                       <<"IsTruncated">> => <<"true">>,
-                       <<"NextContinuationToken">> => <<"b">>},
+                                             <<"LastModified">> => <<"123">>}}},
                      {200, [], make_ref()}};
                    (_Cli, _Bucket, #{<<"prefix">> := _,
                                      <<"continuation-token">> := <<"b">>}, _) ->
                     {ok,
                      #{<<"ListBucketResult">> =>
                        #{<<"KeyCount">> => <<"2">>,
+                         <<"IsTruncated">> => <<"true">>,
+                         <<"NextContinuationToken">> => <<"d">>,
                          <<"Contents">> => [
                             #{<<"Key">> => <<"dir/c">>, <<"LastModified">> => <<"123">>},
                             #{<<"Key">> => <<"dir/d">>, <<"LastModified">> => <<"123">>}
-                        ]},
-                       <<"IsTruncated">> => <<"true">>,
-                       <<"NextContinuationToken">> => <<"d">>},
+                        ]}},
                      {200, [], make_ref()}};
                    (_Cli, _Bucket, #{<<"prefix">> := _,
                                      <<"continuation-token">> := <<"d">>}, _) ->


### PR DESCRIPTION
If you start a directory monitor as a server in S3 mode and do so by creating a directory object, it will get returned in listing queries. Unfortunately, the list calls will require an `is_regular/1` check (which would be "costly") to filter out.

Instead, add an implicit check in S3 where an object with a trailing `/` is considered to be a directory and is ignored. This is generally safe since MacOS and Linux forbid `/` in paths and shouldn't happen outside of such manual S3 object creations.

More importantly though, this fixes directory listing pagination within S3's API use. Turns out the translation from integration tests to unit tests was wrong and if in practice a directory in S3 was encountered with over 1000 files, pagination failed and the tracking failed on every restart.

That took a while to figure out.