### PR TITLE
Set upper bound on {active, N} settings

### DIFF
--- a/apps/revault/src/revault_tls.hrl
+++ b/apps/revault/src/revault_tls.hrl
@@ -6,6 +6,7 @@
 -define(CLIENT(Name), {via, gproc, {n, l, {tls, client, Name}}}).
 -define(BACKOFF_THRESHOLD, 500).
 -define(MIN_ACTIVE, 8).
+-define(MAX_ACTIVE, 4096).
 -record(client, {name, dirs, peer, dir, auth, opts, sock,
                  recv = false, buf = revault_tls:buf_new(),
                  active=?MIN_ACTIVE, ctx = []}).

--- a/apps/revault/src/revault_tls_client.erl
+++ b/apps/revault/src/revault_tls_client.erl
@@ -120,7 +120,7 @@ handle_event(info, {pong, T}, connected, Data=#client{sock=Sock, active=Active})
     Now = erlang:monotonic_time(millisecond),
     NewActive = case Now - T > ?BACKOFF_THRESHOLD of
         true -> max(Active div 2, ?MIN_ACTIVE);
-        false -> Active * 2
+        false -> min(Active * 2, ?MAX_ACTIVE)
     end,
     ssl:setopts(Sock, [{active, NewActive}]),
     {keep_state, Data#client{active=NewActive}, []};

--- a/apps/revault/src/revault_tls_serv.erl
+++ b/apps/revault/src/revault_tls_serv.erl
@@ -259,7 +259,7 @@ worker_loop(Dir, C=#conn{localname=Name, sock=Sock, buf=Buf0, active=Active}) ->
             Now = erlang:monotonic_time(millisecond),
             NewActive = case Now - T > ?BACKOFF_THRESHOLD of
                 true -> max(Active div 2, ?MIN_ACTIVE);
-                false -> Active * 2
+                false -> min(Active * 2, ?MAX_ACTIVE)
             end,
             ssl:setopts(Sock, [{active, NewActive}]),
             worker_loop(Dir, C#conn{active=NewActive});


### PR DESCRIPTION
On a particularly quick network with wide buffers, it appears we can overflow the number and crash arbitrary connections.

A few thousands packets ought to be enough to still reach decent speeds without killing the underlying stack.